### PR TITLE
파일 업로드 api 구현 및 instance 수정 및 파일 업로드 관련 로직 변경 논의

### DIFF
--- a/src/frontend/apps/web/src/features/chat/api/uploadFile.api.ts
+++ b/src/frontend/apps/web/src/features/chat/api/uploadFile.api.ts
@@ -1,0 +1,38 @@
+import { postRequest } from '@/src/shared/services/apis';
+
+type FileUploadItem = {
+  fileTypes: 'IMAGE' | 'VIDEO';
+  fileIds: number;
+};
+
+type FileUploadRequest = {
+  channelId: number;
+  workspaceId: number;
+  files: File[];
+  thumbnails: (File | null)[];
+};
+
+export async function uploadFiles({
+  channelId,
+  workspaceId,
+  files,
+  thumbnails,
+}: FileUploadRequest): Promise<FileUploadItem[]> {
+  const formData = new FormData();
+
+  formData.append('channelId', channelId.toString());
+  formData.append('workspaceId', workspaceId.toString());
+
+  files.forEach((file) => formData.append('files', file));
+
+  // thumbnails 배열의 요소가 null인 경우, 문자열 "null"으로 대체
+  thumbnails.forEach((thumb) =>
+    formData.append('thumbnails', thumb === null ? 'null' : thumb),
+  );
+
+  for (const [key, value] of formData.entries()) {
+    console.log('debugging', key, value);
+  }
+
+  return postRequest<FileUploadItem[], FormData>('/api/v1/files', formData);
+}

--- a/src/frontend/apps/web/src/features/chat/api/uploadFile.api.ts
+++ b/src/frontend/apps/web/src/features/chat/api/uploadFile.api.ts
@@ -34,5 +34,9 @@ export async function uploadFiles({
     console.log('debugging', key, value);
   }
 
-  return postRequest<FileUploadItem[], FormData>('/api/v1/files', formData);
+  return postRequest<FileUploadItem[], FormData>(
+    'file',
+    '/api/v1/files',
+    formData,
+  );
 }

--- a/src/frontend/apps/web/src/features/chat/model/file-data.type.ts
+++ b/src/frontend/apps/web/src/features/chat/model/file-data.type.ts
@@ -1,8 +1,6 @@
 export type FileData = {
-  id: string;
-  name: string;
-  file: File;
-  preview: string;
-  thumbnailUrl?: string;
-  type: 'image' | 'video';
+  workspaceId: string;
+  channelId: string;
+  file: File[];
+  thumbnailUrl?: File[];
 };

--- a/src/frontend/apps/web/src/features/chat/model/use-file-managements.ts
+++ b/src/frontend/apps/web/src/features/chat/model/use-file-managements.ts
@@ -1,46 +1,42 @@
 import type { FileData } from './file-data.type';
-import { validateFileSize, generateVideoThumbnail } from '../lib/file.utils';
-import { useState, useEffect } from 'react';
+import {
+  validateFileSize,
+  generateVideoThumbnail,
+  validateTotalFileSize,
+} from '../lib/file.utils';
+import { useState } from 'react';
+import { uploadFiles } from '../api/uploadFile.api';
 
-/**
- * 파일 관리를 위한 커스텀 훅
- * @returns {Object} 파일 관리 관련 메서드와 상태
- * - selectedFiles: 선택된 파일 목록
- * - handleFileChange: 파일 선택 이벤트 핸들러
- * - handleRemoveFile: 파일 제거 메서드
- * - setSelectedFiles: 파일 목록 설정 함수
- */
-export const useFileManagements = () => {
+type ProcessedFile = {
+  file: File;
+  thumbnailFile: File | null;
+};
+
+export const useFileManagements = (workspaceId: number, channelId: number) => {
   const [selectedFiles, setSelectedFiles] = useState<FileData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
-  const processFile = async (file: File): Promise<FileData | null> => {
+  const processFile = async (file: File): Promise<ProcessedFile | null> => {
     if (!validateFileSize(file)) return null;
 
-    const fileData: FileData = {
-      id: Math.random().toString(36).substring(7),
-      name: file.name,
-      file,
-      preview: URL.createObjectURL(file),
-      type: file.type.startsWith('image/') ? 'image' : 'video',
-    };
+    if (file.type.startsWith('image/')) {
+      // 이미지 파일: thumbnailFile은 null 처리
+      return { file, thumbnailFile: null };
+    }
 
-    if (fileData.type === 'video') {
+    if (file.type.startsWith('video/')) {
       try {
-        fileData.thumbnailUrl = await generateVideoThumbnail(file);
-      } catch (error) {
-        console.error('Failed to generate thumbnail:', error);
+        const thumbnailFile = await generateVideoThumbnail(file);
+        return { file, thumbnailFile };
+      } catch (err) {
+        console.error('Failed to generate thumbnail:', err);
+        return { file, thumbnailFile: null };
       }
     }
 
-    return fileData;
+    return null;
   };
-
-  /**
-   * 파일 선택 이벤트 핸들러
-   * @param event - 파일 input 이벤트
-   */
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -50,29 +46,61 @@ export const useFileManagements = () => {
 
     try {
       const files = Array.from(event.target.files || []);
+      // 파일 재선택을 위해 input 초기화
       event.target.value = '';
 
-      const processedFiles = await Promise.all(files.map(processFile));
+      if (!validateTotalFileSize(files)) {
+        setIsLoading(false);
+        return;
+      }
 
-      setSelectedFiles((prev) => [...prev, ...processedFiles.filter(Boolean)]);
-    } catch (error) {
-      setError(error as Error);
+      // 선택한 파일들을 순서대로 전처리
+      const processedResults = await Promise.all(files.map(processFile));
+      const processedFiles = processedResults.filter(
+        (f): f is ProcessedFile => f !== null,
+      );
+
+      // 원래 선택 순서를 유지하여 파일 배열과 썸네일 배열 구성
+      const fileArray = processedFiles.map((item) => item.file);
+      const thumbnailArray = processedFiles.map((item) => item.thumbnailFile);
+
+      // 백엔드 API 호출을 위한 payload 구성
+      // API 함수 uploadFiles는 채널, 워크스페이스 ID를 number로 받으므로 변환합니다.
+      const payload = {
+        channelId: Number(channelId),
+        workspaceId: Number(workspaceId),
+        files: fileArray,
+        thumbnails: thumbnailArray,
+      };
+      // console.log('Payload:', payload);
+
+      const response = await uploadFiles(payload);
+      console.log('Upload response:', response);
+
+      // 미리보기 상태(FileData) 생성 및 추가
+      const newFileData: FileData = {
+        workspaceId: workspaceId.toString(),
+        channelId: channelId.toString(),
+        file: fileArray,
+        thumbnailUrl: thumbnailArray.filter(
+          (thumb): thumb is File => thumb !== null,
+        ),
+      };
+
+      setSelectedFiles((prev) => [...prev, newFileData]);
+    } catch (err) {
+      console.error('Error during file processing/upload:', err);
+      setError(err as Error);
     } finally {
       setIsLoading(false);
     }
   };
 
-  /**
-   * 파일 제거 메서드
-   * @param id - 제거할 파일의 ID
-   */
-  const handleRemoveFile = (id: string) => {
+  const handleRemoveFile = (index: number) => {
     setSelectedFiles((prev) => {
-      const fileToRemove = prev.find((file) => file.id === id);
-      if (fileToRemove) {
-        URL.revokeObjectURL(fileToRemove.preview);
-      }
-      return prev.filter((file) => file.id !== id);
+      const newFiles = [...prev];
+      newFiles.splice(index, 1);
+      return newFiles;
     });
   };
 

--- a/src/frontend/apps/web/src/features/chat/model/use-file-managements.ts
+++ b/src/frontend/apps/web/src/features/chat/model/use-file-managements.ts
@@ -54,6 +54,14 @@ export const useFileManagements = (workspaceId: number, channelId: number) => {
         return;
       }
 
+      selectedFiles.forEach((fileData) => {
+        fileData.file.forEach((file) => {
+          if (file instanceof File && file.type.startsWith('video/')) {
+            URL.revokeObjectURL(file.name);
+          }
+        });
+      });
+
       // 선택한 파일들을 순서대로 전처리
       const processedResults = await Promise.all(files.map(processFile));
       const processedFiles = processedResults.filter(

--- a/src/frontend/apps/web/src/features/chat/ui/avatarlist.tsx
+++ b/src/frontend/apps/web/src/features/chat/ui/avatarlist.tsx
@@ -29,7 +29,7 @@ const AvatarList = ({
 
   return (
     <div
-      className="px-1 py-1 pr-40 mb-0.5 flex gap-1 items-center justify-between hover:shadow-md cursor-pointer"
+      className="px-1 py-1 pr-10 mb-0.5 flex gap-1 items-center justify-between hover:shadow-md cursor-pointer"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={() => setIsThreadOpen(true)}

--- a/src/frontend/apps/web/src/features/chat/ui/chat-toggle-group.tsx
+++ b/src/frontend/apps/web/src/features/chat/ui/chat-toggle-group.tsx
@@ -30,10 +30,10 @@ const ChatToggleGroup = ({ name, onSend }: ChatToggleGroupsProps) => {
     <div className="flex flex-col justify-between gap-2">
       {error && <div className="text-red-500">{error.message}</div>}
 
-      <FilePreviewList
+      {/* <FilePreviewList
         selectedFiles={selectedFiles}
         onRemoveFile={() => {}}
-      />
+      /> */}
       <div className="flex flex-row justify-between">
         <div className="flex flex-row gap-4 items-center">
           <FileUploadTrigger

--- a/src/frontend/apps/web/src/features/chat/ui/chat-toggle-group.tsx
+++ b/src/frontend/apps/web/src/features/chat/ui/chat-toggle-group.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback } from 'react';
+import { useState } from 'react';
 
 import { Button } from '@workspace/ui/components';
 
@@ -15,13 +15,16 @@ type ChatToggleGroupsProps = {
 };
 
 const ChatToggleGroup = ({ name, onSend }: ChatToggleGroupsProps) => {
+  const [isUploading, setIsUploading] = useState<boolean>(false);
   const {
     selectedFiles,
     handleFileChange,
     handleRemoveFile,
     isLoading,
     error,
-  } = useFileManagements();
+  } = useFileManagements(1, 1);
+
+  console.log('123', selectedFiles);
 
   return (
     <div className="flex flex-col justify-between gap-2">
@@ -29,19 +32,13 @@ const ChatToggleGroup = ({ name, onSend }: ChatToggleGroupsProps) => {
 
       <FilePreviewList
         selectedFiles={selectedFiles}
-        onRemoveFile={useCallback(
-          (id) => handleRemoveFile(id),
-          [handleRemoveFile],
-        )}
+        onRemoveFile={() => {}}
       />
       <div className="flex flex-row justify-between">
         <div className="flex flex-row gap-4 items-center">
           <FileUploadTrigger
             name={name}
-            onFileChange={useCallback(
-              (event) => handleFileChange(event),
-              [handleFileChange],
-            )}
+            onFileChange={handleFileChange}
           />
           {isLoading && (
             <Loader

--- a/src/frontend/apps/web/src/features/chat/ui/file-modal.tsx
+++ b/src/frontend/apps/web/src/features/chat/ui/file-modal.tsx
@@ -29,7 +29,7 @@ const FileModal = ({
       <div className="p-6">
         {/* 헤더 */}
         <div className="flex justify-between items-center mb-6">
-          <div className="flex items-center gap-3">
+          {/* <div className="flex items-center gap-3">
             <span className="p-2 bg-gray-100 rounded-lg">
               {fileData.type === 'image' ? '🖼️' : '🎥'}
             </span>
@@ -42,12 +42,12 @@ const FileModal = ({
                 {formatFileSize(fileData.file.size)}
               </p>
             </div>
-          </div>
+          </div> */}
         </div>
 
         {/* 컨텐츠 영역 */}
         <div className="rounded-xl overflow-hidden bg-gray-50">
-          {fileData.type === 'image' ? (
+          {/* {fileData.type === 'image' ? (
             <div className="relative w-full h-[40vh]">
               <Image
                 src={fileData.preview}
@@ -70,7 +70,7 @@ const FileModal = ({
                 Your browser does not support the video tag.
               </video>
             </div>
-          )}
+          )} */}
         </div>
 
         {/* 푸터 */}

--- a/src/frontend/apps/web/src/features/chat/ui/file-preview-item.tsx
+++ b/src/frontend/apps/web/src/features/chat/ui/file-preview-item.tsx
@@ -21,7 +21,7 @@ export const FilePreviewItem = ({
 
   return (
     <div className="relative group flex-shrink-0">
-      <div className="w-20 h-20 rounded-lg relative overflow-hidden border border-black">
+      {/* <div className="w-20 h-20 rounded-lg relative overflow-hidden border border-black">
         {fileData.type === 'image' ? (
           <ImagePreivew
             preview={fileData.preview}
@@ -41,15 +41,15 @@ export const FilePreviewItem = ({
           color="#EA4335"
           className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity"
         />
-      </div>
-      {isModalOpen && (
+      </div> */}
+      {/* {isModalOpen && (
         <FileModal
           isOpen={isModalOpen}
           setIsOpen={setIsModalOpen}
           size="default"
           fileData={fileData}
         />
-      )}
+      )} */}
     </div>
   );
 };

--- a/src/frontend/apps/web/src/features/chat/ui/file-preview-list.tsx
+++ b/src/frontend/apps/web/src/features/chat/ui/file-preview-list.tsx
@@ -19,13 +19,13 @@ export const FilePreviewList = ({
   return (
     <div className="overflow-x-auto w-full">
       <div className="flex gap-2 pb-2 w-max">
-        {selectedFiles.map((fileData) => (
+        {/* {selectedFiles.map((fileData) => (
           <FilePreviewItem
             key={fileData.id}
             fileData={fileData}
             onRemove={onRemoveFile}
           />
-        ))}
+        ))} */}
       </div>
     </div>
   );

--- a/src/frontend/apps/web/src/shared/services/apis/fetch-method.api.ts
+++ b/src/frontend/apps/web/src/shared/services/apis/fetch-method.api.ts
@@ -1,5 +1,8 @@
-import type { FetchOptions, JsonValue } from '@/src/shared/services/models';
-
+import type {
+  ApiServerType,
+  FetchOptions,
+  JsonValue,
+} from '@/src/shared/services/models';
 import { fetchInstance } from './fetch-instance.api';
 
 type RequestOptions<TBody = never> = Omit<FetchOptions<TBody>, 'body'>;
@@ -24,12 +27,16 @@ type RequestOptions<TBody = never> = Omit<FetchOptions<TBody>, 'body'>;
  * const data = await getRequest<UserData>('/api/users/me');
  *
  * // 쿼리 파라미터와 캐시 옵션과 토큰이 없을때 GET 요청
- * const users = await getRequest<User[]>('/api/users', {
- *   params: { page: '1', size: '10' },
- *   cache: 'force-cache',
- *   tags: ['users'],
- *   includeAuthToken: false,
- * });
+ * const users = await getRequest<User[]>(
+ *   "auth",
+ *   '/api/users',
+ *   {
+ *    params: { page: '1', size: '10' },
+ *    cache: 'force-cache',
+ *    tags: ['users'],
+ *    includeAuthToken: false,
+ *   }
+ * );
  * ```
  *
  * * GET 요청을 보내는 함수입니다.
@@ -38,10 +45,11 @@ type RequestOptions<TBody = never> = Omit<FetchOptions<TBody>, 'body'>;
  */
 
 export async function getRequest<TResponse>(
+  serverType: ApiServerType,
   url: string,
   options?: RequestOptions,
 ): Promise<TResponse> {
-  return fetchInstance<TResponse>(url, 'GET', options);
+  return fetchInstance<TResponse>(serverType, url, 'GET', options);
 }
 
 /**
@@ -62,6 +70,7 @@ export async function getRequest<TResponse>(
  * ```typescript
  * // 사용자 생성 요청
  * const newUser = await postRequest<User, CreateUserDto>(
+ *   "auth",
  *   '/api/users',
  *   { name: 'John', email: 'john@example.com' }
  * );
@@ -73,11 +82,15 @@ export async function getRequest<TResponse>(
  */
 
 export async function postRequest<TResponse, TBody = JsonValue>(
+  serverType: ApiServerType,
   url: string,
   body: TBody,
   options?: RequestOptions<TBody>,
 ): Promise<TResponse> {
-  return fetchInstance<TResponse, TBody>(url, 'POST', { ...options, body });
+  return fetchInstance<TResponse, TBody>(serverType, url, 'POST', {
+    ...options,
+    body,
+  });
 }
 
 /**
@@ -98,6 +111,7 @@ export async function postRequest<TResponse, TBody = JsonValue>(
  * ```typescript
  * // 사용자 정보 업데이트
  * const updatedUser = await patchRequest<User, UpdateUserDto>(
+ *   "auth",
  *   `/api/users/${userId}`,
  *   { name: 'Updated Name' },
  *   { tags: ['user-profile'] }
@@ -110,11 +124,15 @@ export async function postRequest<TResponse, TBody = JsonValue>(
  *
  */
 export async function patchRequest<TResponse, TBody = JsonValue>(
+  serverType: ApiServerType,
   url: string,
   body: TBody,
   options?: RequestOptions<TBody>,
 ): Promise<TResponse> {
-  return fetchInstance<TResponse, TBody>(url, 'PATCH', { ...options, body });
+  return fetchInstance<TResponse, TBody>(serverType, url, 'PATCH', {
+    ...options,
+    body,
+  });
 }
 
 /**
@@ -138,6 +156,7 @@ export async function patchRequest<TResponse, TBody = JsonValue>(
  *
  * // 본문과 함께 삭제 요청
  * await deleteRequest<void, DeletePostDto>(
+ *   "file",
  *   `/api/posts/${postId}`,
  *   { reason: 'spam' },
  *   { tags: ['posts'] }
@@ -149,9 +168,13 @@ export async function patchRequest<TResponse, TBody = JsonValue>(
  * @throws {NetworkError} 네트워크 연결에 문제가 있을 때 발생합니다
  */
 export async function deleteRequest<TResponse, TBody = JsonValue>(
+  serverType: ApiServerType,
   url: string,
   body?: TBody,
   options?: RequestOptions<TBody>,
 ): Promise<TResponse> {
-  return fetchInstance<TResponse, TBody>(url, 'DELETE', { ...options, body });
+  return fetchInstance<TResponse, TBody>(serverType, url, 'DELETE', {
+    ...options,
+    body,
+  });
 }

--- a/src/frontend/apps/web/src/shared/services/lib/index.ts
+++ b/src/frontend/apps/web/src/shared/services/lib/index.ts
@@ -1,0 +1,1 @@
+export { getBaseUrl } from './utils';

--- a/src/frontend/apps/web/src/shared/services/lib/utils.ts
+++ b/src/frontend/apps/web/src/shared/services/lib/utils.ts
@@ -1,0 +1,25 @@
+import { ApiServerType } from '@/src/shared/services/models';
+
+export const getBaseUrl = (serverType: ApiServerType): string => {
+  const ports: Record<ApiServerType, string | undefined> = {
+    gateway: process.env.NEXT_PUBLIC_GATEWAY_SERVER_PORT,
+    auth: process.env.NEXT_PUBLIC_AUTH_SERVER_PORT,
+    stock: process.env.NEXT_PUBLIC_STOCK_SERVER_PORT,
+    file: process.env.NEXT_PUBLIC_FILE_SERVER_PORT,
+    chat1: process.env.NEXT_PUBLIC_CHAT_SERVER1_PORT,
+    chat2: process.env.NEXT_PUBLIC_CHAT_SERVER2_PORT,
+    history: process.env.NEXT_PUBLIC_HISTORY_SERVER_PORT,
+    workspace: process.env.NEXT_PUBLIC_WORKSPACE_SERVER_PORT,
+    push: process.env.NEXT_PUBLIC_PUSH_SERVER_PORT,
+    state: process.env.NEXT_PUBLIC_STATE_SERVER_PORT,
+    signaling: process.env.NEXT_PUBLIC_SIGNALING_SERVER_PORT,
+  };
+
+  const port = ports[serverType];
+
+  if (!port) {
+    throw new Error(`❌ Unknown serverType: ${serverType}`);
+  }
+
+  return `http://${process.env.NEXT_PUBLIC_BASE_URL}:${port}`;
+};

--- a/src/frontend/apps/web/src/shared/services/models/types/fetch-types.d.ts
+++ b/src/frontend/apps/web/src/shared/services/models/types/fetch-types.d.ts
@@ -21,3 +21,22 @@ export type ApiResponse<T> = {
 };
 
 export type ApiErrorResponse = Omit<ApiResponse<never>, 'data'>;
+
+export const API_SERVER_TYPES = {
+  gateway: 'gateway',
+  auth: 'auth',
+  stock: 'stock',
+  file: 'file',
+  chat1: 'chat1',
+  chat2: 'chat2',
+  history: 'history',
+  workspace: 'workspace',
+  push: 'push',
+  state: 'state',
+  signaling: 'signaling',
+} as const;
+
+/**
+ * API 서버 타입을 유추하도록 타입 생성
+ */
+export type ApiServerType = keyof typeof API_SERVER_TYPES;

--- a/src/frontend/apps/web/src/shared/services/models/types/index.ts
+++ b/src/frontend/apps/web/src/shared/services/models/types/index.ts
@@ -7,4 +7,5 @@ export type {
   FetchOptions,
   ApiErrorResponse,
   ApiResponse,
+  ApiServerType,
 } from './fetch-types.js';

--- a/src/frontend/turbo.json
+++ b/src/frontend/turbo.json
@@ -1,5 +1,20 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": [
+    "NEXT_PUBLIC_MODE",
+    "NEXT_PUBLIC_BASE_URL",
+    "NEXT_PUBLIC_GATEWAY_SERVER_PORT",
+    "NEXT_PUBLIC_AUTH_SERVER_PORT",
+    "NEXT_PUBLIC_STOCK_SERVER_PORT",
+    "NEXT_PUBLIC_FILE_SERVER_PORT",
+    "NEXT_PUBLIC_CHAT_SERVER1_PORT",
+    "NEXT_PUBLIC_CHAT_SERVER2_PORT",
+    "NEXT_PUBLIC_HISTORY_SERVER_PORT",
+    "NEXT_PUBLIC_WORKSPACE_SERVER_PORT",
+    "NEXT_PUBLIC_PUSH_SERVER_PORT",
+    "NEXT_PUBLIC_STATE_SERVER_PORT",
+    "NEXT_PUBLIC_SIGNALING_SERVER_PORT"
+  ],
   "ui": "tui",
   "tasks": {
     "build": {
@@ -39,7 +54,11 @@
     },
     "typescript": {
       "dependsOn": ["^typescript"],
-      "inputs": ["$TURBO_DEFAULT$", "tsconfig.json", "packages/**/tsconfig.json"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "tsconfig.json",
+        "packages/**/tsconfig.json"
+      ],
       "cache": true,
       "persistent": false
     }


### PR DESCRIPTION
# Pull request

<!---
IMPORTANT: Please do not create a Pull Request without first creating an issue and
reading our contributing guidelines (docs/CONTRIBUTING.md)

You can skip this if you're fixing a typo.
--->

## Related issue

<!---
Copybara Action only accepts pull requests related to open issues
If suggesting a new feature or change, please discuss it in an issue first
If fixing a bug, there should be an issue describing it with steps to reproduce
Please link to the issue here
-->

- resolves #69 @KimKyuHoi 

## Motivation and context

<!---
Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.
--->

- API Path
```tsx
"http://localhost:8083/api/v1/files"

```
- Request Headers
```JSON
"Content-Type" : "application/json"
"Authorization" :  "Bearer AccessToken"
```
- Request Body(Example)
```JSON
{
   "workspaceId": 1,
   "channelId": 1,
   "files": ["Files"],
   "thumbnails":  ["Files"],
}

```
- Response Body(Example)
```JSON
{
    "fileTypes": [
        "IMAGE",
        "IMAGE",
        "VIDEO"
    ],
    "fileIds": [
        23,
        24,
        25
    ],
}
```

---

- 파일 업로드 및 API 기능 
  - post를 사용한 file 일반화 
- fetchInstance 경로별 중앙화

## Solution

<!---
Describe the modifications you've done.
What will change as a result of your pull request?
--->

- fetch Instance 경로 설정
  - 이전 코드내에서는 instance내에 경로가 없었음.
  - const assertion을 통한 port 타입 지정
  - instance내에서 무조건 Content-Type이 강제적으로 'application/json'으로 강제화 되었으나 스프레드연산자와 삼항조건을 사용하여 조건 2가지를 생성하였고, 이를 Record 제너릭을 통해 합체.
- file Upload 구현 개선 및 기능 변경 필요.🚨🚨🚨🚨🚨 @mirlee0304 
  -  현재의 Response Body로는 미리보기 기능 구현이 불가능함.
  - null을 Form-Data로 보내는것도 추천하지 않으며 또한 data값을 활용하기 매우 어려움.
  - fileUpload시 (다중 파일 업로드 개수 4개, 총량 137.8mb 기준)
  - **첫번째 시도했을때의 예시 이미지**
   <img width="1015" alt="image" src="https://github.com/user-attachments/assets/f1612b3f-b0cc-4566-b132-79c9312c8b50" />
   - 총 9.476s 경과
   - **두번째 시도했을때의 예시 이미지**
   <img width="1015" alt="image" src="https://github.com/user-attachments/assets/80a28e95-1a01-4df3-a7c6-f4af53ce593e" />
   - 총 15.784s 경과
   - **세번째 시도했을때의 예시 이미지**
   <img width="1013" alt="image" src="https://github.com/user-attachments/assets/dbe19d99-e508-4873-b949-793b13c7905f" />
   - 총 11.286s 경과

   => 총 3회 시도시 평균 12.182s 소요

   -  fileUpload시 (다중 파일 업로드 개수 15개, 총량 176.12mb 기준)
   <img width="1016" alt="image" src="https://github.com/user-attachments/assets/0df99249-b7f5-4dd9-a45c-1c326441060d" />
   - 총 52.799s 경과

   => 파일개수만 늘어났을텐데 시간이 기하 급수적으로 늘어나게 됨.


**예상되는 이유**
- 현재 로직
  - FE내에서 썸네일까지 만드는 로직을 담당하고 있음
  - 파일을 업로드하는 과정내에서 항상 썸네일 생성하는 로직이 관여하기에 기하급수적으로 시간이 늘어날 수 밖에 없음.
  - 또한, 용량이 큰 파일이나 다중 파일 업로드 시 백엔드에서 발생하는 I/O 부담이 증가하여 전체 성능 저하로 이어질 수 있음
  - 그래서 로직 개선이 필요하다고 생각함.
=> 청크방식으로 개선해보면 어떨까라는 생각이 듭니다. 
- 청크 방식 적용 제안:
  - 파일을 작은 청크(조각)로 분할해 업로드를 병렬 및 비동기적으로 처리함으로써, 각 요청의 부하를 줄이고 전체 업로드 시간을 단축시킬 수 있음.
  - 청크 단위로 업로드를 진행하면, 실패 시 해당 청크만 재전송할 수 있어 네트워크 불안정에 대한 내성이 향상됨.
  - 백엔드에서의 I/O 부담을 분산시키고, 대용량 파일 및 다중 파일 업로드 상황에서도 안정적인 성능을 유지할 수 있을 것으로 기대됨.

## How has this been tested

<!---
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
If this change has an impact on UX, include screenshots or a video.
--->

https://github.com/user-attachments/assets/1fbc41ec-fd0b-4d11-b746-55be0af46808




<!-- project-pull-request -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
