### PR TITLE
히스토리서버 채널별 과거 채팅 조회 api(역방향) 구현

### DIFF
--- a/src/backend/history_server/src/main/java/com/jootalkpia/history_server/controller/HistoryController.java
+++ b/src/backend/history_server/src/main/java/com/jootalkpia/history_server/controller/HistoryController.java
@@ -17,7 +17,7 @@ public class HistoryController {
     private static final String DEFAULT_PAGE_SIZE = "30";
     private final HistoryQueryService historyQueryService;
 
-    @GetMapping("/api/v1/history/{channelId}")
+    @GetMapping("/api/v1/history/forward/{channelId}")
     public ChatMessagePageResponse getChatMessagesForward(
             @PathVariable Long channelId,
             //처음 요청시엔 서버 내에서 안읽은 메세지 값으로 설정하기 위해 false
@@ -28,4 +28,6 @@ public class HistoryController {
         return historyQueryService.
                 getChatMessagesForward(channelId, cursorId, size, userInfo.userId());
     }
+
+
 }

--- a/src/backend/history_server/src/main/java/com/jootalkpia/history_server/controller/HistoryController.java
+++ b/src/backend/history_server/src/main/java/com/jootalkpia/history_server/controller/HistoryController.java
@@ -29,5 +29,15 @@ public class HistoryController {
                 getChatMessagesForward(channelId, cursorId, size, userInfo.userId());
     }
 
-
+    @GetMapping("/api/v1/history/backward/{channelId}")
+    public ChatMessagePageResponse getChatMessagesBackward(
+            @PathVariable Long channelId,
+            //처음 요청시엔 서버 내에서 안읽은 메세지 값으로 설정하기 위해 false
+            // 이때 message의 objectId가 아닌 threadId가 기준
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = DEFAULT_PAGE_SIZE) int size,
+            @CurrentUser UserInfo userInfo) {
+        return historyQueryService.
+                getChatMessagesBackward(channelId, cursorId, size, userInfo.userId());
+    }
 }

--- a/src/backend/history_server/src/main/java/com/jootalkpia/history_server/repository/ChatMessageRepository.java
+++ b/src/backend/history_server/src/main/java/com/jootalkpia/history_server/repository/ChatMessageRepository.java
@@ -14,6 +14,9 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
     // cursorId 이후의 메시지 조회 (정방향)
     List<ChatMessage> findByChannelIdAndThreadIdGreaterThanOrderByThreadIdAsc(Long channelId, Long threadId, Pageable pageable);
 
+    // 첫 요청 시 최신 메시지를 찾기 위한 쿼리
+    Optional<ChatMessage> findTopByChannelIdOrderByThreadIdDesc(Long channelId);
+
     // 역방향 조회 (lastReadId 이하의 메시지)
     List<ChatMessage> findByChannelIdAndThreadIdLessThanEqualOrderByThreadIdDesc(Long channelId, Long threadId, Pageable pageable);
 }

--- a/src/backend/history_server/src/main/java/com/jootalkpia/history_server/repository/ChatMessageRepository.java
+++ b/src/backend/history_server/src/main/java/com/jootalkpia/history_server/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.jootalkpia.history_server.repository;
 
 import com.jootalkpia.history_server.domain.ChatMessage;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
@@ -9,6 +10,10 @@ import java.util.List;
 
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
-    // cursorId 이후의 메시지 조회 (페이징)
+
+    // cursorId 이후의 메시지 조회 (정방향)
     List<ChatMessage> findByChannelIdAndThreadIdGreaterThanOrderByThreadIdAsc(Long channelId, Long threadId, Pageable pageable);
+
+    // 역방향 조회 (lastReadId 이하의 메시지)
+    List<ChatMessage> findByChannelIdAndThreadIdLessThanEqualOrderByThreadIdDesc(Long channelId, Long threadId, Pageable pageable);
 }

--- a/src/backend/history_server/src/main/java/com/jootalkpia/history_server/service/HistoryQueryService.java
+++ b/src/backend/history_server/src/main/java/com/jootalkpia/history_server/service/HistoryQueryService.java
@@ -84,7 +84,16 @@ public class HistoryQueryService {
     private List<ChatMessage> fetchMessagesBackward(Long channelId, Long cursorId, int size, Long userId) {
         Long lastReadId = cursorId;
 
+        // 첫 요청 시 처리
+        if (cursorId == null) {
+            lastReadId = userChannelRepository.findLastReadIdByUserIdAndChannelId(userId, channelId);
 
+
+            // 채널 내 메시지가 없는 경우 빈 리스트 반환
+            if (lastReadId == null) {
+                return Collections.emptyList();
+            }
+        }
 
         // lastReadId 이하의 메시지를 최신순 (DESC)으로 조회
         return chatMessageRepository.findByChannelIdAndThreadIdLessThanEqualOrderByThreadIdDesc(

--- a/src/backend/history_server/src/main/java/com/jootalkpia/history_server/service/HistoryQueryService.java
+++ b/src/backend/history_server/src/main/java/com/jootalkpia/history_server/service/HistoryQueryService.java
@@ -88,6 +88,12 @@ public class HistoryQueryService {
         if (cursorId == null) {
             lastReadId = userChannelRepository.findLastReadIdByUserIdAndChannelId(userId, channelId);
 
+            // lastReadId가 null이면 (첫 입장 시) 가장 최신 메세지로 설정
+            if (lastReadId == null) {
+                lastReadId = chatMessageRepository.findTopByChannelIdOrderByThreadIdDesc(channelId)
+                        .map(ChatMessage::getThreadId) // 가장 최신 메시지의 threadId 반환
+                        .orElse(null); // 채널에 메시지가 없으면 null 반환
+            }
 
             // 채널 내 메시지가 없는 경우 빈 리스트 반환
             if (lastReadId == null) {


### PR DESCRIPTION
# Pull request

<!---
IMPORTANT: Please do not create a Pull Request without first creating an issue and
reading our contributing guidelines (docs/CONTRIBUTING.md)

You can skip this if you're fixing a typo.
--->

## Related issue
resolve #226 
<!---
Copybara Action only accepts pull requests related to open issues
If suggesting a new feature or change, please discuss it in an issue first
If fixing a bug, there should be an issue describing it with steps to reproduce
Please link to the issue here
-->

## Motivation and context
- 채널별 과거 채팅 조회 api(역방향)을 구현하였습니다.
- 페이징 기능을 포함하였습니다.
   - hasNext 여부를 반환하는 구조를 설계했습니다.
   - 첫 요청 시 cursorId 없이 요청할 수 있도록 처리하였고 이때 마지막 읽은 시점을 포함하여 조회할 수 있도록 하였습니다.
<!---
Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.
--->

## Solution
- 채널 내 채팅 메시지 조회 API (역방향) 구현
   - cursorId가 있는 경우: 해당 cursorId 이전의 메시지를 조회
   - cursorId가 없는 경우 (첫 요청): userChannelRepository에서 마지막 읽은 메시지(lastReadId)를 조회하여, 해당 ID부터 메시지를 가져옴
      - 이때 lastReadId가 없는 경우 (채널에 첫 입장 시): 채널의 가장 최근 메세지부터 조회
      
- 페이징 기능 및 hasNext 구현
   - 요청한 size보다 1개 더 많은 메시지를 가져와서, 다음 페이지가 있는지(hasNext) 확인
size + 1의 크기가 size보다 크면 hasNext = true 반환 후, 마지막 메시지는 응답에서 제외
@RequestParam(defaultValue = "30")를 사용하여 기본 페이지 크기를 30으로 설정
마지막 메시지의 ID 반환
   - 응답 데이터에 마지막 메시지의 threadId를 포함하여, 클라이언트에서 이후 메시지를 조회할 때 cursorId로 활용 가능

<!---
Describe the modifications you've done.
What will change as a result of your pull request?
--->

## How has this been tested
- cursorId가 없는데 lastReadId도 없는 경우
   <img width="1612" alt="스크린샷 2025-02-20 오후 9 58 58" src="https://github.com/user-attachments/assets/c81db09b-3c6b-47d8-9351-c5d94d2b7100" />

- cursorId가 없는데 lastReadId는 있는 경우
   <img width="972" alt="스크린샷 2025-02-20 오후 10 03 20" src="https://github.com/user-attachments/assets/20c75fcb-c28e-4b26-8b5a-84cc0a94341e" />

- cursorId가 있는 경우
   <img width="600" alt="스크린샷 2025-02-20 오후 10 01 05" src="https://github.com/user-attachments/assets/635f55ce-900d-423e-a6d4-f80f1145196d" />

- size보다 남은 데이터가 적은경우
   <img width="607" alt="스크린샷 2025-02-20 오후 10 00 22" src="https://github.com/user-attachments/assets/7fbfe8c3-8fee-4d02-9eda-132f3e4f74c3" />

<!---
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
If this change has an impact on UX, include screenshots or a video.
--->

<!-- project-pull-request -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
