### PR TITLE
다중 세션 환경에서의 실시간 알림 전달 시스템 구현

### DIFF
--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/WebSocketConfig.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/WebSocketConfig.java
@@ -15,13 +15,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
-
     private final StompConnectInterceptor stompConnectInterceptor;
     private final StompSubscriptionInterceptor stompSubscriptionInterceptor;
     private final StompValidationInterceptor stompValidationInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/subscribe");
         config.setApplicationDestinationPrefixes("/publish"); // STOMP 메시지 발행 prefix
     }
 

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/WebSocketConfig.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/WebSocketConfig.java
@@ -21,7 +21,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/subscribe");
         config.setApplicationDestinationPrefixes("/publish"); // STOMP 메시지 발행 prefix
     }
 

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/interceptor/StompSubscriptionInterceptor.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/interceptor/StompSubscriptionInterceptor.java
@@ -27,6 +27,7 @@ public class StompSubscriptionInterceptor implements ChannelInterceptor {
     private static final long SESSION_EXPIRY_HOURS = 4;
     private static final String DEFAULT_CHANNEL = "none";
     private static final Long DEFAULT_ID = 1L;
+    private static final String SUBSCRIBE_CHAT_PREFIX = "/subscribe/chat.";
 
     private final RedisTemplate<String, String> stringOperRedisTemplate;
     private final RedisTemplate<String, Object> objectOperRedisTemplate;
@@ -79,7 +80,9 @@ public class StompSubscriptionInterceptor implements ChannelInterceptor {
             return;
         }
 
-        handleChatSubscription(accessor);
+        if (accessor.getDestination().startsWith(SUBSCRIBE_CHAT_PREFIX)) {
+            handleChatSubscription(accessor);
+        }
     }
 
     private void handleUnsubscription(StompHeaderAccessor accessor) {

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/interceptor/StompValidationInterceptor.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/config/interceptor/StompValidationInterceptor.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StompValidationInterceptor implements ChannelInterceptor {
     private static final String HEADER_USER_ID = "X-User-ID";
-    private static final String SUBSCRIBE_CHAT_PREFIX = "/subscribe/chat.";
+    private static final String SUBSCRIBE_PREFIX = "/subscribe";
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -39,6 +39,6 @@ public class StompValidationInterceptor implements ChannelInterceptor {
     }
 
     private boolean isValidChatDestination(String destination) {
-        return destination != null && destination.startsWith(SUBSCRIBE_CHAT_PREFIX);
+        return destination != null && destination.startsWith(SUBSCRIBE_PREFIX);
     }
 }

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/PushMessage.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/PushMessage.java
@@ -1,0 +1,11 @@
+package com.jootalkpia.chat_server.dto;
+
+public record PushMessage(
+        String userNickname,
+        String channelName,
+        String text
+) {
+    public static PushMessage from(PushMessageToKafka pushMessageToKafka) {
+        return new PushMessage(pushMessageToKafka.userNickName(), pushMessageToKafka.channelName(), pushMessageToKafka.text());
+    }
+}

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/PushMessageToKafka.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/PushMessageToKafka.java
@@ -1,0 +1,11 @@
+package com.jootalkpia.chat_server.dto;
+
+public record PushMessageToKafka(
+        String sessionId,
+        String userNickName,
+        String channelId,
+        String channelName,
+        String workspaceId,
+        String text
+) {
+}

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/ReadCountMessage.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/ReadCountMessage.java
@@ -1,0 +1,10 @@
+package com.jootalkpia.chat_server.dto;
+
+public record ReadCountMessage(
+        String channelId,
+        String channelName
+) {
+    public static ReadCountMessage from(PushMessageToKafka pushMessageToKafka) {
+        return new ReadCountMessage(pushMessageToKafka.channelId(), pushMessageToKafka.channelName());
+    }
+}

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
@@ -1,8 +1,10 @@
 package com.jootalkpia.chat_server.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jootalkpia.chat_server.dto.ChatMessageToKafka;
 import com.jootalkpia.chat_server.dto.MinutePriceResponse;
+import com.jootalkpia.chat_server.dto.PushMessageToKafka;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -25,6 +27,7 @@ public class KafkaConsumer {
     )
     public void processMinutePrice(String kafkaMessage) {
         log.info("Received Kafka minute message ===> {}", kafkaMessage);
+
         try {
             MinutePriceResponse stockUpdate = objectMapper.readValue(kafkaMessage, MinutePriceResponse.class);
             String stockDataJson = objectMapper.writeValueAsString(stockUpdate);
@@ -45,15 +48,36 @@ public class KafkaConsumer {
     )
     public void processChatMessage(@Header(KafkaHeaders.RECEIVED_KEY) String channelId, String kafkaMessage) {
         log.info("Received Kafka message ===> channelId: {}, message: {}", channelId, kafkaMessage);
+
         try {
             ChatMessageToKafka chatMessage = objectMapper.readValue(kafkaMessage, ChatMessageToKafka.class);
             String chatDataJson = objectMapper.writeValueAsString(chatMessage);
 
             messagingTemplate.convertAndSend("/subscribe/chat." + channelId, chatDataJson);
             log.info("Broadcasted chat message via WebSocket: {}", chatDataJson);
+            log.info("/subscribe/chat." + channelId);
 
         } catch (Exception ex) {
             log.error("Error processing chat message: {}", ex.getMessage(), ex);
+        }
+    }
+
+    @KafkaListener(
+            topics = "${topic.push}",
+            groupId = "${group.push}"
+    )
+    public void processPushMessage(String kafkaMessage) {
+        log.info("message ===> " + kafkaMessage);
+
+        try {
+            PushMessageToKafka pushMessageToKafka = objectMapper.readValue(kafkaMessage, PushMessageToKafka.class);
+            String cleanSessionId = pushMessageToKafka.sessionId().replace("\"", "");
+
+            messagingTemplate.convertAndSend("/subscribe/notification." + cleanSessionId, pushMessageToKafka);
+
+            log.info("dto ===> " + pushMessageToKafka);
+        } catch (Exception ex) {
+            log.error(ex.getMessage(), ex); // 추후에 GlobalException 처리
         }
     }
 }

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
@@ -61,7 +61,8 @@ public class KafkaConsumer {
 
     @KafkaListener(
             topics = "${topic.push}",
-            groupId = "${group.push}"
+            groupId = "${group.push}",
+            concurrency = "2"
     )
     public void processPushMessage(String kafkaMessage) {
         log.info("message ===> " + kafkaMessage);

--- a/src/backend/chat_server/src/main/resources/application.yml
+++ b/src/backend/chat_server/src/main/resources/application.yml
@@ -37,10 +37,12 @@ logging:
 topic:
   minute: jootalkpia.stock.prd.minute
   chat: jootalkpia.chat.prd.message
+  push: jootalkpia.push.prd.message
 
 group:
   minute: minute-price-save-consumer-group
   chat: chat-message-handle-consumer-group-${SERVER_PORT}
+  push: push-message-handle-consumer-group
 
 server:
  port: ${SERVER_PORT}

--- a/src/backend/chat_server/src/main/resources/application.yml
+++ b/src/backend/chat_server/src/main/resources/application.yml
@@ -42,7 +42,7 @@ topic:
 group:
   minute: minute-price-save-consumer-group
   chat: chat-message-handle-consumer-group-${SERVER_PORT}
-  push: push-message-handle-consumer-group
+  push: push-message-handle-consumer-group-${SERVER_PORT}
 
 server:
  port: ${SERVER_PORT}

--- a/src/backend/state_server/build.gradle
+++ b/src/backend/state_server/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/ChatMessageToKafka.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/ChatMessageToKafka.java
@@ -1,8 +1,0 @@
-package com.jootalkpia.state_server;
-
-public record ChatMessageToKafka(
-        Long userId,
-        String username,
-        String content
-) {
-}

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/dto/ChannelInfo.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/dto/ChannelInfo.java
@@ -1,0 +1,7 @@
+package com.jootalkpia.state_server.dto;
+
+public record ChannelInfo(
+        Long workSpaceId,
+        String name
+) {
+}

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/dto/CommonData.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/dto/CommonData.java
@@ -1,0 +1,24 @@
+package com.jootalkpia.state_server.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record CommonData(
+        String channelId,
+        String threadId,
+        String threadDateTime,
+        String userId,
+        String userNickName,
+        String userProfileImage
+) {
+
+    public static CommonData from(JsonNode common) {
+        return new CommonData(
+                common.get("channelId").asText(),
+                common.get("threadId").asText(),
+                common.get("threadDateTime").asText(),
+                common.get("userId").asText(),
+                common.get("userNickname").asText(),
+                common.get("userProfileImage").asText()
+        );
+    }
+}

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/dto/PushMessageToKafka.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/dto/PushMessageToKafka.java
@@ -1,0 +1,28 @@
+package com.jootalkpia.state_server.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.jootalkpia.state_server.entity.common.MessageType;
+
+public record PushMessageToKafka(
+        String sessionId,
+        String userNickName,
+        String channelId,
+        String channelName,
+        String workspaceId,
+        String text
+) {
+    public static PushMessageToKafka from(String sessionId, CommonData commonData, JsonNode messagesNode, ChannelInfo channelInfo) {
+        JsonNode firstMessageNode = messagesNode.get(0);
+        String messageType = firstMessageNode.get("type").asText();
+        MessageType type = MessageType.from(messageType);
+
+        return new PushMessageToKafka(
+                sessionId,
+                commonData.userNickName(),
+                commonData.channelId(),
+                channelInfo.name(),
+                String.valueOf(channelInfo.workSpaceId()),
+                type.createText(firstMessageNode)
+        );
+    }
+}

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/entity/common/MessageType.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/entity/common/MessageType.java
@@ -1,0 +1,34 @@
+package com.jootalkpia.state_server.entity.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public enum MessageType {
+    TEXT {
+        @Override
+        public String createText(JsonNode messageNode) {
+            return messageNode.get("text").asText();
+        }
+    },
+    IMAGE {
+        @Override
+        public String createText(JsonNode messageNode) {
+            return "파일을 공유함" + messageNode.get("imageUrl");
+        }
+    },
+    VIDEO {
+        @Override
+        public String createText(JsonNode messageNode) {
+            return "동영상을 공유함" + messageNode.get("videoId");
+        }
+    };
+
+    public abstract String createText(JsonNode messageNode);
+
+    public static MessageType from(String type) {
+        try {
+            return MessageType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 메시지 타입입니다: ");
+        }
+    }
+}

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/entity/common/RedisKeys.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/entity/common/RedisKeys.java
@@ -1,4 +1,4 @@
-package com.jootalkpia.state_server.entity;
+package com.jootalkpia.state_server.entity.common;
 
 public class RedisKeys {
     private static final String SESSION_PREFIX = "sessions";

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/repository/ChannelRepository.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/repository/ChannelRepository.java
@@ -1,0 +1,24 @@
+package com.jootalkpia.state_server.repository;
+
+import com.jootalkpia.state_server.dto.ChannelInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChannelRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    public ChannelInfo findChannelFromId(Long channelId) {
+        String sql = "SELECT c.workspace_id, c.name FROM channels c WHERE c.channel_id = ?";
+
+        return jdbcTemplate.queryForObject(sql,
+                (rs, rowNum) -> new ChannelInfo(
+                        rs.getLong("workspace_id"),
+                        rs.getString("name")
+                ),
+                channelId
+        );
+    }
+}

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/KafkaConsumer.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/KafkaConsumer.java
@@ -17,6 +17,7 @@ public class KafkaConsumer {
     private static final String COMMON = "common";
     private static final String MESSAGE = "message";
     private static final String CHANNEL_ID = "channelId";
+    private static final String USER_ID = "userId";
 
     @KafkaListener(
             topics = "${topic.chat}",
@@ -33,8 +34,9 @@ public class KafkaConsumer {
             JsonNode messagesNode = rootNode.get(MESSAGE);
 
             String channelId = commonNode.get(CHANNEL_ID).asText();
+            String userId = commonNode.get(USER_ID).asText();
 
-            for (String sessionId : stateService.findNotificationTargets(channelId)) {
+            for (String sessionId : stateService.findNotificationTargets(channelId, userId)) {
                 kafkaProducer.sendPushMessage(stateService.createPushMessage(commonNode, messagesNode, sessionId));
             }
 

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/KafkaProducer.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/KafkaProducer.java
@@ -1,7 +1,7 @@
 package com.jootalkpia.state_server.service;
 
 import com.google.gson.Gson;
-import com.jootalkpia.state_server.ChatMessageToKafka;
+import com.jootalkpia.state_server.dto.PushMessageToKafka;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -11,12 +11,11 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 public class KafkaProducer {
-
     private final Gson gson = new Gson();
     private final KafkaTemplate<String, String> kafkaTemplate;
 
-    public void sendPushMessage(ChatMessageToKafka chatMessageToKafka) { // DTO 변경 필요
-        String jsonChatMessage = gson.toJson(chatMessageToKafka);
+    public void sendPushMessage(PushMessageToKafka pushMessageToKafka) {
+        String jsonChatMessage = gson.toJson(pushMessageToKafka);
         kafkaTemplate.send("jootalkpia.push.prd.message", jsonChatMessage).whenComplete((result, ex) -> {
             if (ex == null) {
                 log.info(result.toString());

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/StateService.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/StateService.java
@@ -24,17 +24,17 @@ public class StateService {
 
     private final ChannelRepository channelRepository;
 
-    public PushMessageToKafka createPushMessage(JsonNode commonNode,JsonNode messagesNode, String sessionId) {
+    public PushMessageToKafka createPushMessage(JsonNode commonNode, JsonNode messagesNode, String sessionId) {
         CommonData commonData = CommonData.from(commonNode);
         ChannelInfo channelInfo = channelRepository.findChannelFromId(Long.valueOf(commonData.channelId()));
 
         return PushMessageToKafka.from(sessionId, commonData, messagesNode, channelInfo);
     }
 
-    public Set<String> findNotificationTargets(String channelId) {
+    public Set<String> findNotificationTargets(String channelId, String userId) {
         Set<String> subscriber = findSubscribers(channelId);
-        Set<String> onlineSessions = findOnlineSessions(subscriber);
-        Set<String> activeSessions = findActiveSessions(channelId, subscriber);
+        Set<String> onlineSessions = findOnlineSessions(userId, subscriber);
+        Set<String> activeSessions = findActiveSessions(channelId, subscriber, userId);
 
         log.info("[Notification Targets] Channel: {}", channelId);
         log.info("├── Online Sessions: {}", onlineSessions);
@@ -50,35 +50,69 @@ public class StateService {
         return stringOperRedisTemplate.opsForSet().members(RedisKeys.channelSubscribers(channelId));
     }
 
-    private Set<String> findOnlineSessions(Set<String> subscriber) {
+    private Set<String> findOnlineSessions(String messagePublisher, Set<String> subscribers) {
         Set<String> onlineSessions = new HashSet<>();
 
-        for (String userId : subscriber) {
-            Set<String> userSessions = stringOperRedisTemplate.opsForSet()
-                    .members(RedisKeys.userSessions(userId));
-            if (userSessions != null) {
-                onlineSessions.addAll(userSessions);
+        for (String userId : subscribers) {
+            if (isNotPublisher(userId, messagePublisher)) {
+                addUserSessions(userId, onlineSessions);
             }
         }
 
         return onlineSessions;
     }
 
-    private Set<String> findActiveSessions(String channelId, Set<String> subscriber) {
+    private boolean isNotPublisher(String userId, String messagePublisher) {
+        return !userId.equals(messagePublisher);
+    }
+
+    private void addUserSessions(String userId, Set<String> onlineSessions) {
+        Set<String> userSessions = findUserSessions(userId);
+
+        if (userSessions != null) {
+            onlineSessions.addAll(userSessions);
+        }
+    }
+
+    private Set<String> findUserSessions(String userId) {
+        return stringOperRedisTemplate.opsForSet()
+                .members(RedisKeys.userSessions(userId));
+    }
+
+    private Set<String> findActiveSessions(String channelId, Set<String> subscribers, String messagePublisher) {
         Set<String> activeSessions = new HashSet<>();
 
-        for (String userId : subscriber) {
-            Object userActiveSessions = objectOperRedisTemplate.opsForHash()
-                    .get(RedisKeys.channelActive(channelId), userId);
-
-            if (userActiveSessions != null) {
-                Set<String> sessions = convertToSet(userActiveSessions);
-                sessions.forEach(session ->
-                        activeSessions.add("\"" + session + "\""));
+        for (String userId : subscribers) {
+            if (isNotPublisher(userId, messagePublisher)) {
+                addActiveSessionsForUser(channelId, userId, activeSessions);
             }
         }
 
         return activeSessions;
+    }
+
+    private void addActiveSessionsForUser(String channelId, String userId, Set<String> activeSessions) {
+        Object userActiveSessions = getUserActiveSessions(channelId, userId);
+
+        if (userActiveSessions != null) {
+            Set<String> sessions = convertToSet(userActiveSessions);
+            addQuotedSessions(sessions, activeSessions);
+        }
+    }
+
+    private Object getUserActiveSessions(String channelId, String userId) {
+        return objectOperRedisTemplate.opsForHash()
+                .get(RedisKeys.channelActive(channelId), userId);
+    }
+
+    private void addQuotedSessions(Set<String> sessions, Set<String> activeSessions) {
+        for (String session : sessions) {
+            activeSessions.add(formatSessionWithQuotes(session));
+        }
+    }
+
+    private String formatSessionWithQuotes(String session) {
+        return "\"" + session + "\"";
     }
 
     @SuppressWarnings("unchecked")

--- a/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/StateService.java
+++ b/src/backend/state_server/src/main/java/com/jootalkpia/state_server/service/StateService.java
@@ -1,6 +1,11 @@
 package com.jootalkpia.state_server.service;
 
-import com.jootalkpia.state_server.entity.RedisKeys;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.jootalkpia.state_server.dto.ChannelInfo;
+import com.jootalkpia.state_server.dto.CommonData;
+import com.jootalkpia.state_server.dto.PushMessageToKafka;
+import com.jootalkpia.state_server.entity.common.RedisKeys;
+import com.jootalkpia.state_server.repository.ChannelRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -16,6 +21,15 @@ import java.util.Set;
 public class StateService {
     private final RedisTemplate<String, String> stringOperRedisTemplate;
     private final RedisTemplate<String, Object> objectOperRedisTemplate;
+
+    private final ChannelRepository channelRepository;
+
+    public PushMessageToKafka createPushMessage(JsonNode commonNode,JsonNode messagesNode, String sessionId) {
+        CommonData commonData = CommonData.from(commonNode);
+        ChannelInfo channelInfo = channelRepository.findChannelFromId(Long.valueOf(commonData.channelId()));
+
+        return PushMessageToKafka.from(sessionId, commonData, messagesNode, channelInfo);
+    }
 
     public Set<String> findNotificationTargets(String channelId) {
         Set<String> subscriber = findSubscribers(channelId);

--- a/src/backend/state_server/src/main/resources/application.yml
+++ b/src/backend/state_server/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
 
 topic:
   chat: jootalkpia.chat.prd.message


### PR DESCRIPTION
# Pull request

<!---
IMPORTANT: Please do not create a Pull Request without first creating an issue and
reading our contributing guidelines (docs/CONTRIBUTING.md)

You can skip this if you're fixing a typo.
--->

## Related issue

* Resolve #255 
* Resolve #256 

<!---
Copybara Action only accepts pull requests related to open issues
If suggesting a new feature or change, please discuss it in an issue first
If fixing a bug, there should be an issue describing it with steps to reproduce
Please link to the issue here
-->

## Motivation and context

채팅 메시지 발송 시 해당 채팅방을 구독하고 있는 온라인 사용자들에게 실시간 알림을 전달하기 위한 기능이 필요했습니다. 특히 사용자가 여러 브라우저 탭에서 동시에 접속할 경우, 각각의 세션에 대해 독립적으로 알림을 전달할 수 있도록 하는 것이 중요했습니다.

추가로 메시지를 발행한 사용자는 본인이 발행한 메시지에 대한 알림과 읽지 않은 메시지 카운트 증가 이벤트를 받지 않도록 하는 필터링 로직이 필요했습니다. 이를 위해 Kafka를 통한 메시지 전달과 WebSocket을 이용한 실시간 알림 전송 로직을 구현했습니다.

<!---
Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.
--->

## Solution

### 1. WebSocket 설정 개선
* 온라인 세션 조회 로직 개선 - Redis를 활용한 사용자별 세션 관리
* 메시지 발행자 필터링 로직 추가 - 본인이 발행한 메시지의 알림/카운트 증가 제외
* 다중 탭 환경을 위한 세션별 독립적인 구독 처리

### 2. 메시지 처리 로직 구현
* 메시지 타입별 destination 분리
    * 세션 기반 실시간 알림: /subscribe/notification.{sessionId}
    * 워크스페이스 기반 읽지 않은 메시지 카운트: /subscribe/notification.{sessionId}/workspace.{workspaceId}
* 채널 활성 세션 조회 기능 구현 - Redis Hash 자료구조 활용
* 세션 ID 기반의 정확한 메시지 전달 처리

### 3. 채널 정보 조회 기능 추가
* 채널 정보 조회를 위한 Repository 구현
* JDBC를 통한 데이터베이스 연동

<!---
Describe the modifications you've done.
What will change as a result of your pull request?
--->

## How has this been tested
1. 사용자 A가 채팅방에 메시지 전송
2. State 서버에서 해당 채팅방 구독자 목록 조회
3. 온라인 상태인 구독자들의 세션 ID 확인 (다중 탭 환경 테스트)
4. Push 토픽으로 알림 메시지 전송
5. Chat 서버에서 해당 토픽을 수신
6. Chat 서버에서 WebSocket을 통해 해당 세션의 클라이언트로 메시지 전달
7. 클라이언트에서 알림 메시지 수신 확인
* 동일 사용자의 여러 탭에서 각각 정상적으로 알림 수신 확인
* 탭 간 알림 중복 및 누락 여부 확인

<img width="1916" alt="image" src="https://github.com/user-attachments/assets/203393d1-7326-4726-8855-23f1c07e9414" />

* user 1이 2개의 브라우저 탭을 띄워 각각 채널 3과 2를 구독
* user 2가 채널 3을 구독
* 두 user 모두 채널 3에 참여되어 있는 상태
* user 2가 채널 3에 접속된 브라우저로 메세지 전달
* user 1의 브라우저 중 채널 3에 접속된 브라우저는 채팅 메세지를 받음
* user 1의 브라우저 중 채널 2에 접속된 브라우저는 알림 메세지를 받음 

<!---
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
If this change has an impact on UX, include screenshots or a video.
--->

<!-- project-pull-request -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
