### PR TITLE
워크스페이스 채널 생성시 socket 로직 구현

### DIFF
--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/WorkspaceToKafka.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/WorkspaceToKafka.java
@@ -1,0 +1,8 @@
+package com.jootalkpia.chat_server.dto;
+
+public record WorkspaceToKafka(
+        Long workspaceId,
+        Long ChannelId,
+        String ChannelName
+) {
+}

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/WorkspaceToKafka.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/dto/WorkspaceToKafka.java
@@ -1,8 +1,12 @@
 package com.jootalkpia.chat_server.dto;
 
+import java.time.LocalDateTime;
+
 public record WorkspaceToKafka(
         Long workspaceId,
-        Long ChannelId,
-        String ChannelName
+        Long createUserId,
+        Long channelId,
+        String channelName,
+        LocalDateTime createdAt
 ) {
 }

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
@@ -114,7 +114,7 @@ public class KafkaConsumer {
             String workspaceDataJson = objectMapper.writeValueAsString(workspaceData);
             Long workspaceId = workspaceData.workspaceId();
 
-            messagingTemplate.convertAndSend("/subscribe/workspace" + workspaceId, workspaceDataJson);
+            messagingTemplate.convertAndSend("/subscribe/workspace." + workspaceId, workspaceDataJson);
 
             log.info("Broadcasted workspace data via WebSocket: " + workspaceDataJson);
 

--- a/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
+++ b/src/backend/chat_server/src/main/java/com/jootalkpia/chat_server/service/KafkaConsumer.java
@@ -2,6 +2,7 @@ package com.jootalkpia.chat_server.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jootalkpia.chat_server.dto.*;
+import com.jootalkpia.chat_server.dto.WorkspaceToKafka;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -43,7 +44,7 @@ public class KafkaConsumer {
             concurrency = "2"
     )
     public void processChatMessage(@Header(KafkaHeaders.RECEIVED_KEY) String channelId, String kafkaMessage) {
-        log.info("Received Kafka message ===> channelId: {}, message: {}", channelId, kafkaMessage);
+        log.info("Received Kafka chat message ===> channelId: {}, message: {}", channelId, kafkaMessage);
         try {
             ChatMessageToKafka chatMessage = objectMapper.readValue(kafkaMessage, ChatMessageToKafka.class);
             String chatDataJson = objectMapper.writeValueAsString(chatMessage);
@@ -107,18 +108,18 @@ public class KafkaConsumer {
             groupId = "${group.workspace}"
     )
     public void processChannelStatusMessage(String kafkaMessage) {
-        log.info("message ===> " + kafkaMessage);
-
-        ObjectMapper mapper = new ObjectMapper();
-
+        log.info("Received Kafka workspace message ===> {}", kafkaMessage);
         try {
-            ChatMessageToKafka chatMessageToKafka = mapper.readValue(kafkaMessage, ChatMessageToKafka.class); //추후 DTO 변경 필수
+            WorkspaceToKafka workspaceData = objectMapper.readValue(kafkaMessage, WorkspaceToKafka.class);
+            String workspaceDataJson = objectMapper.writeValueAsString(workspaceData);
+            Long workspaceId = workspaceData.workspaceId();
 
-            // 채널 생성 및 상태 정보 데이터 전달하는 로직
+            messagingTemplate.convertAndSend("/subscribe/workspace" + workspaceId, workspaceDataJson);
 
-            log.info("dto ===> " + chatMessageToKafka.toString());
+            log.info("Broadcasted workspace data via WebSocket: " + workspaceDataJson);
+
         } catch (Exception ex) {
-            log.error(ex.getMessage(), ex); // 추후에 GlobalException 처리
+            log.error("Error processing stock message: " + ex.getMessage(), ex);
         }
     }
 }

--- a/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/controller/WorkSpaceController.java
+++ b/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/controller/WorkSpaceController.java
@@ -41,7 +41,7 @@ public class WorkSpaceController {
         ValidationUtils.validateWorkSpaceId(workspaceId);
         log.info("Creating channels for workspace with id: {}", workspaceId);
 
-        SimpleChannel channel = workSpaceService.createChannel(workspaceId, channelName);
+        SimpleChannel channel = workSpaceService.createChannel(workspaceId, channelName,userId);
 
         // 유저를 생성된 채널에 가입시킴
         workSpaceService.addMember(workspaceId, userId, channel.getChannelId());

--- a/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/dto/WorkspaceToKafka.java
+++ b/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/dto/WorkspaceToKafka.java
@@ -1,0 +1,8 @@
+package com.jootalkpia.workspace_server.dto;
+
+public record WorkspaceToKafka(
+        Long workspaceId,
+        Long ChannelId,
+        String ChannelName
+) {
+}

--- a/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/dto/WorkspaceToKafka.java
+++ b/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/dto/WorkspaceToKafka.java
@@ -1,8 +1,12 @@
 package com.jootalkpia.workspace_server.dto;
 
+import java.time.LocalDateTime;
+
 public record WorkspaceToKafka(
         Long workspaceId,
-        Long ChannelId,
-        String ChannelName
+        Long createUserId,
+        Long channelId,
+        String channelName,
+        LocalDateTime createdAt
 ) {
 }

--- a/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/service/KafkaProducer.java
+++ b/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/service/KafkaProducer.java
@@ -1,6 +1,7 @@
 package com.jootalkpia.workspace_server.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jootalkpia.workspace_server.dto.WorkspaceToKafka;
 import com.jootalkpia.workspace_server.entity.MessageToKafka;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,10 +16,10 @@ public class KafkaProducer {
     private final ObjectMapper objectMapper;
     private final KafkaTemplate<String, String> kafkaTemplate;
 
-    public void sendChannelStatusMessage(MessageToKafka messageToKafka) { // DTO 변경 필수
+    public void sendChannelStatusMessage(WorkspaceToKafka workspaceToKafka) {
         try {
-            String jsonMessage = objectMapper.writeValueAsString(messageToKafka);
-            kafkaTemplate.send("jootalkpia.workspace.prd.channel", jsonMessage)
+            String workspaceData = objectMapper.writeValueAsString(workspaceToKafka);
+            kafkaTemplate.send("jootalkpia.workspace.prd.channel", workspaceData)
                     .whenComplete((result, ex) -> { //키 값 설정으로 순서 보장, 실시간성이 떨어짐, 고민해봐야 할 부분
                         if (ex == null) {
                             log.info("Kafka message sent: {}", result.toString());

--- a/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/service/WorkSpaceService.java
+++ b/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/service/WorkSpaceService.java
@@ -2,6 +2,7 @@ package com.jootalkpia.workspace_server.service;
 
 import com.jootalkpia.workspace_server.dto.ChannelListDTO;
 import com.jootalkpia.workspace_server.dto.SimpleChannel;
+import com.jootalkpia.workspace_server.dto.WorkspaceToKafka;
 import com.jootalkpia.workspace_server.entity.Channels;
 import com.jootalkpia.workspace_server.entity.ChatMessage;
 import com.jootalkpia.workspace_server.entity.UserChannel;
@@ -36,6 +37,7 @@ public class WorkSpaceService {
     private final WorkSpaceRepository workSpaceRepository;
     private final UserRepository userRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private final KafkaProducer kafkaProducer;
 
     public ChannelListDTO getChannels(Long userId, Long workspaceId) {
         // workspaceId로 모든 채널 조회
@@ -120,6 +122,11 @@ public class WorkSpaceService {
                 .build();
 
         channelRepository.save(channel);
+
+        kafkaProducer.sendChannelStatusMessage(
+                new WorkspaceToKafka(workspaceId,
+                                    channel.getChannelId(),
+                                    channel.getName()));
 
         return new SimpleChannel(channel.getChannelId(), channel.getName(), channel.getCreatedAt(),0L);
     }

--- a/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/service/WorkSpaceService.java
+++ b/src/backend/workspace_server/src/main/java/com/jootalkpia/workspace_server/service/WorkSpaceService.java
@@ -108,7 +108,7 @@ public class WorkSpaceService {
         return channelListDTO;
     }
 
-    public SimpleChannel createChannel(Long workspaceId, String channelName) {
+    public SimpleChannel createChannel(Long workspaceId, String channelName,Long userId) {
         // WorkSpace 객체 조회
         WorkSpace workSpace = fetchWorkSpace(workspaceId);
 
@@ -125,8 +125,10 @@ public class WorkSpaceService {
 
         kafkaProducer.sendChannelStatusMessage(
                 new WorkspaceToKafka(workspaceId,
+                                    userId,
                                     channel.getChannelId(),
-                                    channel.getName()));
+                                    channel.getName()
+                                    ,channel.getCreatedAt()));
 
         return new SimpleChannel(channel.getChannelId(), channel.getName(), channel.getCreatedAt(),0L);
     }


### PR DESCRIPTION
# Pull request

<!---
IMPORTANT: Please do not create a Pull Request without first creating an issue and
reading our contributing guidelines (docs/CONTRIBUTING.md)

You can skip this if you're fixing a typo.
--->

## Related issue
reslove #295
<!---
Copybara Action only accepts pull requests related to open issues
If suggesting a new feature or change, please discuss it in an issue first
If fixing a bug, there should be an issue describing it with steps to reproduce
Please link to the issue here
-->

## Motivation and context
- 채널 생성 시 소켓을 통해 해당 워크스페이스를 구독하고 있는 유저에게 메세지를 보내줍니다.
<!---
Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.
--->

## Solution
- 채널 create과정에 produce를 진행하고 해당 토픽을 채팅서버에서 consume합니다.
- 응답에있는 createUserId로 클라이언트가 로그인한 유저일 경우(로컬스토리지에 저장된 id) 가입한 채널 리스트에 추가하고 , 아닐경우 unJoined채널에 추가합니다.
<!---
Describe the modifications you've done.
What will change as a result of your pull request?
--->

## How has this been tested
- 1번 워크스페이스에서 채널이 생성된 경우 메세지를 받고 unsubscribe할 경우 메세지 안받음
<img width="1880" alt="스크린샷 2025-02-25 오후 5 09 44" src="https://github.com/user-attachments/assets/96d94317-d161-41a6-9611-2ddda9b137c8" />

<!---
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
If this change has an impact on UX, include screenshots or a video.
--->

<!-- project-pull-request -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
