### PR TITLE
File-upload 도메인 테스트 코드 작성 및 최종 테스트 코드 작성

### DIFF
--- a/src/frontend/apps/web/src/features/file-upload/api/uploadChunksQueue.api.ts
+++ b/src/frontend/apps/web/src/features/file-upload/api/uploadChunksQueue.api.ts
@@ -3,16 +3,6 @@ import type { ResponseChunkFileData } from '@/src/entities/file-upload';
 import { uploadChunkWithRetry } from './uploadChunkWithRetry.api';
 import { getUploadConcurrency } from '../lib';
 
-/**
- * 파일 청크들을 네트워크 상태에 따른 병렬성으로 업로드하는 업로드 대기열 함수입니다.
- * 각 청크는 바로 API로 전송됩니다.
- * @param chunks 업로드할 청크 배열
- * @param channelId 채널 ID
- * @param workspaceId 워크스페이스 ID
- * @param tempFileIdentifier 임시 파일 식별자
- * @param chunkSize 청크 사이즈
- * @returns {Promise<ResponseFileUploadItem[]>} 각 청크 업로드 결과 배열
- */
 export const uploadChunksQueue = async (
   chunks: Blob[],
   channelId: number,
@@ -22,7 +12,6 @@ export const uploadChunksQueue = async (
 ): Promise<ResponseChunkFileData[]> => {
   const totalChunk = chunks.length;
   const concurrency = await getUploadConcurrency();
-  // console.log('Starting upload with concurrency:', concurrency);
   const results: ResponseChunkFileData[] = new Array(totalChunk);
   let currentIndex = 0;
 
@@ -30,7 +19,6 @@ export const uploadChunksQueue = async (
     while (currentIndex < totalChunk) {
       const index = currentIndex;
       currentIndex++;
-      // console.log(`[worker ${workerId}] Uploading chunk index:`, index);
 
       try {
         results[index] = await uploadChunkWithRetry(
@@ -42,10 +30,6 @@ export const uploadChunksQueue = async (
           chunkSize,
           index + 1,
         );
-        // console.log(
-        //   `[worker ${workerId}] Upload success for chunk index:`,
-        //   index,
-        // );
       } catch (error) {
         console.error(
           `[worker ${workerId}] Upload failed for chunk index:`,

--- a/src/frontend/apps/web/src/features/file-upload/api/uploadSmallFiles.api.ts
+++ b/src/frontend/apps/web/src/features/file-upload/api/uploadSmallFiles.api.ts
@@ -1,10 +1,6 @@
 import { serverFetchInstance } from '@/src/shared/services/apis';
 import type { ResponseChunkFileData } from '@/src/entities/file-upload';
 
-/**
- * 각 청크 데이터를 개별적으로 업로드하는 함수.
- * 이 함수는 하나의 청크(ChunkInfo 객체)를 API로 전송합니다.
- */
 export async function uploadSmallFiles({
   channelId,
   workspaceId,
@@ -15,11 +11,6 @@ export async function uploadSmallFiles({
   formData.append('channelId', channelId.toString());
   formData.append('workspaceId', workspaceId.toString());
   formData.append('file', file);
-
-  // 디버깅용: formData의 모든 키-값 출력
-  // for (const [key, value] of formData.entries()) {
-  //   console.log('debugging', key, value);
-  // }
 
   try {
     console.log('start upload');

--- a/src/frontend/apps/web/src/features/file-upload/api/uploadThumbnail.api.ts
+++ b/src/frontend/apps/web/src/features/file-upload/api/uploadThumbnail.api.ts
@@ -6,10 +6,6 @@ type ThumbnailData = {
   thumbnail?: File;
 };
 
-/**
- * 각 청크 데이터를 개별적으로 업로드하는 함수.
- * 이 함수는 하나의 청크(ChunkInfo 객체)를 API로 전송합니다.
- */
 export async function uploadThumbnail({
   fileId,
   thumbnail,
@@ -18,11 +14,6 @@ export async function uploadThumbnail({
 
   formData.append('fileId', fileId.toString());
   formData.append('thumbnail', thumbnail);
-
-  // 디버깅용: formData의 모든 키-값 출력
-  // for (const [key, value] of formData.entries()) {
-  //   console.log('debugging', key, value);
-  // }
 
   try {
     const response = await serverFetchInstance<FileResponse, FormData>(

--- a/src/frontend/apps/web/src/features/file-upload/lib/chunkFiles.test.ts
+++ b/src/frontend/apps/web/src/features/file-upload/lib/chunkFiles.test.ts
@@ -1,0 +1,208 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as api from '../api';
+
+// 모킹 설정
+vi.mock('../api', () => ({
+  getPing: vi.fn(),
+}));
+
+describe('chunkFiles.utils.ts', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // 캐시 초기화
+    const { resetCache } = await import('./chunkFiles.utils');
+    resetCache();
+    // performance.now 모킹
+    vi.spyOn(performance, 'now').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getDynamicChunkSize', () => {
+    it('네트워크 지연 시간이 500ms 이하일 때 기본 청크 크기를 반환한다', async () => {
+      const { getDynamicChunkSize, DEFAULT_CHUNK_SIZE } = await import(
+        './chunkFiles.utils'
+      );
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(400); // 400ms 지연
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const chunkSize = await getDynamicChunkSize();
+      expect(chunkSize).toBe(DEFAULT_CHUNK_SIZE); // 200MB
+      expect(api.getPing).toHaveBeenCalled();
+    });
+
+    it('네트워크 지연 시간이 500ms 초과 1000ms 이하일 때 100MB를 반환한다', async () => {
+      const { getDynamicChunkSize } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(700); // 700ms 지연
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const chunkSize = await getDynamicChunkSize();
+      expect(chunkSize).toBe(100 * 1024 * 1024); // 100MB
+    });
+
+    it('네트워크 지연 시간이 1000ms 초과일 때 10MB를 반환한다', async () => {
+      const { getDynamicChunkSize } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(1500); // 1500ms 지연
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const chunkSize = await getDynamicChunkSize();
+      expect(chunkSize).toBe(10 * 1024 * 1024); // 10MB
+    });
+
+    it('네트워크 테스트 실패 시 기본 청크 크기를 반환한다', async () => {
+      const { getDynamicChunkSize, DEFAULT_CHUNK_SIZE } = await import(
+        './chunkFiles.utils'
+      );
+      vi.mocked(api.getPing).mockRejectedValue(new Error('Network error'));
+      const chunkSize = await getDynamicChunkSize();
+      expect(chunkSize).toBe(DEFAULT_CHUNK_SIZE);
+    });
+
+    it('캐시된 청크 크기를 반환한다', async () => {
+      const { getDynamicChunkSize, DEFAULT_CHUNK_SIZE } = await import(
+        './chunkFiles.utils'
+      );
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(400);
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      await getDynamicChunkSize(); // 캐시에 저장
+      vi.mocked(api.getPing).mockClear(); // 호출 횟수 초기화
+      const cachedChunkSizeResult = await getDynamicChunkSize();
+      expect(cachedChunkSizeResult).toBe(DEFAULT_CHUNK_SIZE);
+      expect(api.getPing).not.toHaveBeenCalled(); // 두 번째 호출에서는 호출되지 않음
+    });
+  });
+
+  describe('getUploadConcurrency', () => {
+    it('네트워크 지연 시간이 500ms 이하일 때 동시성 5를 반환한다', async () => {
+      const { getUploadConcurrency } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(300); // 300ms 지연
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const concurrency = await getUploadConcurrency();
+      expect(concurrency).toBe(5);
+      expect(api.getPing).toHaveBeenCalled();
+    });
+
+    it('네트워크 지연 시간이 500ms 초과 1000ms 이하일 때 동시성 3을 반환한다', async () => {
+      const { getUploadConcurrency } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(700); // 700ms 지연
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const concurrency = await getUploadConcurrency();
+      expect(concurrency).toBe(3);
+    });
+
+    it('네트워크 지연 시간이 1000ms 초과일 때 동시성 1을 반환한다', async () => {
+      const { getUploadConcurrency } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(1200); // 1200ms 지연
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const concurrency = await getUploadConcurrency();
+      expect(concurrency).toBe(1);
+    });
+
+    it('네트워크 테스트 실패 시 기본 동시성 3을 반환한다', async () => {
+      const { getUploadConcurrency } = await import('./chunkFiles.utils');
+      vi.mocked(api.getPing).mockRejectedValue(new Error('Network error'));
+      const concurrency = await getUploadConcurrency();
+      expect(concurrency).toBe(3);
+    });
+
+    it('캐시된 동시성을 반환한다', async () => {
+      const { getUploadConcurrency } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(300);
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      await getUploadConcurrency(); // 캐시에 저장
+      vi.mocked(api.getPing).mockClear(); // 호출 횟수 초기화
+      const cachedConcurrency = await getUploadConcurrency();
+      expect(cachedConcurrency).toBe(5);
+      expect(api.getPing).not.toHaveBeenCalled(); // 두 번째 호출에서는 호출되지 않음
+    });
+  });
+
+  describe('createChunks', () => {
+    it('파일을 청크로 나눈다', async () => {
+      const { createChunks } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(400); // 400ms 지연
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      Object.defineProperty(file, 'size', { value: 450 * 1024 * 1024 }); // 450MB
+      vi.spyOn(file, 'slice').mockImplementation((start, end) => {
+        const size = Math.min(end, file.size) - start;
+        const blob = new Blob([''], { type: 'video/mp4' });
+        Object.defineProperty(blob, 'size', {
+          value: size,
+          configurable: true,
+        });
+        return blob;
+      });
+      const chunks = await createChunks(file);
+      expect(chunks.length).toBe(3); // 200MB 청크 2개 + 나머지 50MB
+      expect(chunks[0].size).toBe(200 * 1024 * 1024);
+      expect(chunks[1].size).toBe(200 * 1024 * 1024);
+      expect(chunks[2].size).toBe(50 * 1024 * 1024);
+    });
+
+    it('파일 크기가 청크 크기보다 작을 때 단일 청크를 반환한다', async () => {
+      const { createChunks } = await import('./chunkFiles.utils');
+      vi.spyOn(performance, 'now')
+        .mockReturnValueOnce(0)
+        .mockReturnValueOnce(400);
+      vi.mocked(api.getPing).mockResolvedValue(undefined);
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      Object.defineProperty(file, 'size', { value: 150 * 1024 * 1024 }); // 150MB
+      vi.spyOn(file, 'slice').mockImplementation((start, end) => {
+        const size = Math.min(end, file.size) - start;
+        const blob = new Blob([''], { type: 'video/mp4' });
+        Object.defineProperty(blob, 'size', {
+          value: size,
+          configurable: true,
+        });
+        return blob;
+      });
+      const chunks = await createChunks(file);
+      expect(chunks.length).toBe(1);
+      expect(chunks[0].size).toBe(150 * 1024 * 1024);
+    });
+  });
+
+  describe('generateTempFileIdentifier', () => {
+    it('고유한 파일 식별자를 생성한다', async () => {
+      const { generateTempFileIdentifier } = await import('./chunkFiles.utils');
+      const userId = 123;
+      const timestamp = 1698765432100; // 예: 2023-10-31T12:34:32.100Z
+      const fileIndex = 1;
+      const identifier = generateTempFileIdentifier(
+        userId,
+        timestamp,
+        fileIndex,
+      );
+      expect(identifier).toBe('123-1698765432.100000-1');
+    });
+
+    it('다른 입력값에 대해 고유한 식별자를 생성한다', async () => {
+      const { generateTempFileIdentifier } = await import('./chunkFiles.utils');
+      const id1 = generateTempFileIdentifier(123, 1698765432100, 1);
+      const id2 = generateTempFileIdentifier(124, 1698765432100, 1);
+      const id3 = generateTempFileIdentifier(123, 1698765432200, 1);
+      const id4 = generateTempFileIdentifier(123, 1698765432100, 2);
+      expect(id1).not.toBe(id2);
+      expect(id1).not.toBe(id3);
+      expect(id1).not.toBe(id4);
+    });
+  });
+});

--- a/src/frontend/apps/web/src/features/file-upload/lib/chunkFiles.utils.ts
+++ b/src/frontend/apps/web/src/features/file-upload/lib/chunkFiles.utils.ts
@@ -1,13 +1,14 @@
 import { getPing } from '../api';
 
-let cachedChunkSize: number | null = null;
-let cachedUploadConcurrency: number | null = null;
-const DEFAULT_CHUNK_SIZE = 200 * 1024 * 1024;
+export let cachedChunkSize: number | null = null;
+export let cachedUploadConcurrency: number | null = null;
+export const DEFAULT_CHUNK_SIZE = 200 * 1024 * 1024;
 
-/**
- * 네트워크 지연 시간에 따라 동적으로 청크 사이즈를 결정합니다.
- * @returns {Promise<number>} 결정된 청크 사이즈 (바이트 단위)
- */
+export const resetCache = () => {
+  cachedChunkSize = null;
+  cachedUploadConcurrency = null;
+};
+
 export const getDynamicChunkSize = async (): Promise<number> => {
   if (cachedChunkSize !== null) {
     // console.log('Using cached chunk size:', cachedChunkSize);
@@ -37,11 +38,6 @@ export const getDynamicChunkSize = async (): Promise<number> => {
   return cachedChunkSize;
 };
 
-/**
- * 네트워크 지연 시간에 따라 병렬 업로드 개수를 결정합니다.
- * 빠른 네트워크에서는 5개, 중간이면 3개, 느리면 1개로 조절합니다.
- * @returns {Promise<number>} 동시에 전송할 청크 개수
- */
 export const getUploadConcurrency = async (): Promise<number> => {
   if (cachedUploadConcurrency !== null) {
     // console.log('Using cached upload concurrency:', cachedUploadConcurrency);
@@ -74,11 +70,6 @@ export const getUploadConcurrency = async (): Promise<number> => {
   return cachedUploadConcurrency;
 };
 
-/**
- * 파일을 동적 청크 사이즈에 따라 청크로 분리합니다.
- * @param file 분리할 파일
- * @returns {Promise<Blob[]>} 파일 청크들의 배열
- */
 export const createChunks = async (file: File): Promise<Blob[]> => {
   const chunkSize = await getDynamicChunkSize();
   const chunks: Blob[] = [];
@@ -96,13 +87,6 @@ export const createChunks = async (file: File): Promise<Blob[]> => {
   return chunks;
 };
 
-/**
- * 임시 파일 식별자를 생성합니다.
- * @param userId 사용자 ID
- * @param timestamp 파일 선택 시점의 타임스탬프 (밀리초)
- * @param fileIndex 파일의 인덱스
- * @returns {string} 생성된 임시 파일 식별자
- */
 export const generateTempFileIdentifier = (
   userId: number,
   timestamp: number,

--- a/src/frontend/apps/web/src/features/file-upload/lib/filesUpload.test.ts
+++ b/src/frontend/apps/web/src/features/file-upload/lib/filesUpload.test.ts
@@ -1,0 +1,269 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  generateVideoThumbnail,
+  processFile,
+  blobUrlCache,
+  processedFiles,
+} from './filesUpload.utils';
+import { validateFileSize } from './validateFiles.utils';
+
+// 모킹 설정
+vi.mock('./validateFiles.utils', () => ({
+  validateFileSize: vi.fn(),
+}));
+
+const mockURL = {
+  createObjectURL: vi.fn(() => 'mock-blob-url'),
+  revokeObjectURL: vi.fn(),
+};
+
+describe('filesUpload.utils.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    blobUrlCache.clear();
+    processedFiles.clear();
+
+    // URL 모킹
+    global.URL = mockURL as any;
+
+    // requestAnimationFrame 모킹
+    vi.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0); // 즉시 실행
+      return 0;
+    });
+
+    // console.error 모킹
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // DOM 요소 모킹
+    vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+      if (tagName === 'video') {
+        const video = {
+          autoplay: false,
+          muted: true,
+          preload: 'metadata',
+          _src: '',
+          get src() {
+            return this._src;
+          },
+          set src(value) {
+            this._src = value;
+            setTimeout(() => {
+              if (this.onloadedmetadata) this.onloadedmetadata();
+              if (this.onseeked) this.onseeked();
+            }, 0);
+          },
+          currentTime: 0,
+          duration: 10,
+          videoWidth: 1920,
+          videoHeight: 1080,
+          onloadedmetadata: null,
+          onseeked: null,
+          onerror: null,
+          addEventListener: vi.fn(function (event, handler) {
+            if (event === 'loadedmetadata') this.onloadedmetadata = handler;
+            if (event === 'seeked') this.onseeked = handler;
+            if (event === 'error') this.onerror = handler;
+          }),
+        } as any;
+        return video;
+      }
+      if (tagName === 'canvas') {
+        return {
+          width: 0,
+          height: 0,
+          getContext: vi.fn(() => ({
+            drawImage: vi.fn(),
+          })),
+          toBlob: vi.fn((callback) => {
+            callback(new Blob([''], { type: 'image/webp' }));
+          }),
+        } as any;
+      }
+      return {} as any;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete global.URL;
+  });
+
+  describe('generateVideoThumbnail', () => {
+    it('비디오 파일의 썸네일을 성공적으로 생성한다', async () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      const thumbnail = await generateVideoThumbnail(file);
+
+      expect(thumbnail).toBeInstanceOf(File);
+      expect(thumbnail?.name).toBe('thumbnail.webp');
+      expect(thumbnail?.type).toBe('image/webp');
+      expect(blobUrlCache.has(file.name)).toBe(false);
+      expect(mockURL.createObjectURL).toHaveBeenCalledWith(file);
+      expect(mockURL.revokeObjectURL).toHaveBeenCalledWith('mock-blob-url');
+    });
+
+    it('캐시된 Blob URL을 사용하여 썸네일을 반환한다', async () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      blobUrlCache.set(file.name, 'cached-blob-url');
+
+      const thumbnail = await generateVideoThumbnail(file);
+
+      expect(thumbnail).toBeInstanceOf(File);
+      expect(thumbnail?.name).toBe('thumbnail.webp');
+      expect(thumbnail?.type).toBe('image/webp');
+      expect(mockURL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it('타임아웃 발생 시 에러를 반환한다', async () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      vi.useFakeTimers();
+      vi.spyOn(document, 'createElement').mockImplementationOnce(
+        () =>
+          ({
+            autoplay: false,
+            muted: true,
+            preload: 'metadata',
+            src: '',
+            addEventListener: vi.fn(),
+          }) as any,
+      );
+
+      const promise = generateVideoThumbnail(file);
+      vi.advanceTimersByTime(7000);
+
+      await expect(promise).rejects.toThrow('Thumbnail generation timeout');
+      expect(console.error).toHaveBeenCalledWith(
+        'Thumbnail generation timeout.',
+      );
+      expect(blobUrlCache.has(file.name)).toBe(false);
+      expect(mockURL.revokeObjectURL).toHaveBeenCalledWith('mock-blob-url');
+      vi.useRealTimers();
+    });
+
+    // it('비디오 로드 실패 시 에러를 반환한다', async () => {
+    //   const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+    //   vi.spyOn(document, 'createElement').mockImplementationOnce(
+    //     () =>
+    //       ({
+    //         autoplay: false,
+    //         muted: true,
+    //         preload: 'metadata',
+    //         src: '',
+    //         addEventListener: vi.fn((event, handler) => {
+    //           if (event === 'error') handler(new Error('Video load error'));
+    //         }),
+    //       }) as any,
+    //   );
+
+    //   await expect(generateVideoThumbnail(file)).rejects.toThrow(
+    //     'Video load error',
+    //   );
+    //   expect(console.error).toHaveBeenCalledWith(
+    //     'Error generating video thumbnail:',
+    //     expect.any(Error),
+    //   );
+    //   expect(blobUrlCache.has(file.name)).toBe(false);
+    //   expect(mockURL.revokeObjectURL).toHaveBeenCalledWith('mock-blob-url');
+    // });
+
+    // it('Blob 생성 실패 시 에러를 반환한다', async () => {
+    //   const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+    //   vi.spyOn(document, 'createElement').mockImplementation((tagName) => {
+    //     if (tagName === 'canvas') {
+    //       return {
+    //         width: 0,
+    //         height: 0,
+    //         getContext: vi.fn(() => ({
+    //           drawImage: vi.fn(),
+    //         })),
+    //         toBlob: vi.fn((callback) => callback(null)), // Blob 생성 실패
+    //       } as any;
+    //     }
+    //     return document.createElement(tagName as any);
+    //   });
+
+    //   await expect(generateVideoThumbnail(file)).rejects.toThrow(
+    //     'Blob creation failed',
+    //   );
+    //   expect(blobUrlCache.has(file.name)).toBe(false);
+    //   expect(mockURL.revokeObjectURL).toHaveBeenCalledWith('mock-blob-url');
+    // });
+  });
+
+  describe('processFile', () => {
+    it('파일 크기가 유효하지 않으면 null을 반환한다', async () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      vi.mocked(validateFileSize).mockReturnValue(false);
+
+      const result = await processFile(file);
+
+      expect(result).toBe(null);
+      expect(processedFiles.has(file.name)).toBe(false);
+    });
+
+    it('비디오 파일을 처리하고 썸네일을 생성한다', async () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      vi.mocked(validateFileSize).mockReturnValue(true);
+
+      const result = await processFile(file);
+
+      expect(result).toHaveProperty('file', file);
+      expect(result?.thumbnailFile).toBeInstanceOf(File);
+      expect(result?.thumbnailFile?.name).toBe('thumbnail.webp');
+      expect(processedFiles.has(file.name)).toBe(true);
+      expect(processedFiles.get(file.name)).toEqual(result);
+    });
+
+    it('썸네일 생성 실패 시 thumbnailFile은 null로 설정되고 에러가 로그된다', async () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      vi.mocked(validateFileSize).mockReturnValue(true);
+      vi.spyOn(document, 'createElement').mockImplementationOnce(
+        () =>
+          ({
+            autoplay: false,
+            muted: true,
+            preload: 'metadata',
+            src: '',
+            addEventListener: vi.fn((event, handler) => {
+              if (event === 'error') handler(new Error('Video load error'));
+            }),
+          }) as any,
+      );
+
+      const result = await processFile(file);
+
+      expect(result).toHaveProperty('file', file);
+      expect(result?.thumbnailFile).toBe(null);
+      expect(processedFiles.has(file.name)).toBe(true);
+      expect(processedFiles.get(file.name)).toEqual(result);
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to generate video thumbnail:',
+        expect.any(Error),
+      );
+    });
+
+    it('이미지 파일을 처리하면 thumbnailFile은 null이고 캐시에 저장된다', async () => {
+      const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
+      vi.mocked(validateFileSize).mockReturnValue(true);
+
+      const result = await processFile(file);
+
+      expect(result).toHaveProperty('file', file);
+      expect(result?.thumbnailFile).toBe(null);
+      expect(processedFiles.has(file.name)).toBe(true);
+      expect(processedFiles.get(file.name)).toEqual(result);
+    });
+
+    it('캐시된 파일을 반환한다', async () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      const cachedResult = { file, thumbnailFile: null };
+      processedFiles.set(file.name, cachedResult);
+      vi.mocked(validateFileSize).mockReturnValue(true);
+
+      const result = await processFile(file);
+
+      expect(result).toBe(cachedResult);
+      expect(document.createElement).not.toHaveBeenCalledWith('video');
+    });
+  });
+});

--- a/src/frontend/apps/web/src/features/file-upload/lib/filesUpload.utils.ts
+++ b/src/frontend/apps/web/src/features/file-upload/lib/filesUpload.utils.ts
@@ -2,7 +2,7 @@ import type { ProcessedFile } from '@/src/entities/file-upload';
 
 import { validateFileSize } from './validateFiles.utils';
 
-const blobUrlCache = new Map<string, string>();
+export const blobUrlCache = new Map<string, string>();
 
 export const generateVideoThumbnail = async (
   file: File,
@@ -93,7 +93,7 @@ export const generateVideoThumbnail = async (
   });
 };
 
-const processedFiles = new Map<string, ProcessedFile>();
+export const processedFiles = new Map<string, ProcessedFile>();
 
 export async function processFile(file: File): Promise<ProcessedFile | null> {
   if (!validateFileSize(file)) return null;
@@ -110,11 +110,8 @@ export async function processFile(file: File): Promise<ProcessedFile | null> {
       processedFile = { file, thumbnailFile };
     } catch (err) {
       console.error('Failed to generate video thumbnail:', err);
-      // 썸네일 실패 시 null
     }
   }
-  // 이미지 파일이면 thumbnailFile은 null 그대로
-
   processedFiles.set(file.name, processedFile);
   return processedFile;
 }

--- a/src/frontend/apps/web/src/features/file-upload/lib/formatFileSize.test.ts
+++ b/src/frontend/apps/web/src/features/file-upload/lib/formatFileSize.test.ts
@@ -1,0 +1,40 @@
+import { formatFileSize } from './formatFileSize.util';
+
+describe('formatFileSize function tests', () => {
+  test('should format 0 bytes correctly', () => {
+    expect(formatFileSize(0)).toBe('0 Bytes');
+  });
+
+  test('should format numbers in Bytes range correctly', () => {
+    expect(formatFileSize(100)).toBe('100 Bytes');
+    expect(formatFileSize(1023)).toBe('1023 Bytes');
+  });
+
+  test('should format numbers in KB range correctly', () => {
+    expect(formatFileSize(1024)).toBe('1 KB');
+    expect(formatFileSize(1536)).toBe('1.5 KB');
+    expect(formatFileSize(10240)).toBe('10 KB');
+  });
+
+  test('should format numbers in MB range correctly', () => {
+    expect(formatFileSize(1048576)).toBe('1 MB');
+    expect(formatFileSize(2097152)).toBe('2 MB');
+    expect(formatFileSize(1572864)).toBe('1.5 MB');
+  });
+
+  test('should format numbers in GB range correctly', () => {
+    expect(formatFileSize(1073741824)).toBe('1 GB');
+    expect(formatFileSize(1610612736)).toBe('1.5 GB');
+  });
+
+  test('should correctly display up to 2 decimal places', () => {
+    expect(formatFileSize(1126)).toBe('1.1 KB');
+    expect(formatFileSize(1127)).toBe('1.1 KB');
+    expect(formatFileSize(1177)).toBe('1.15 KB');
+    expect(formatFileSize(1178)).toBe('1.15 KB');
+  });
+
+  test('should handle negative input', () => {
+    expect(formatFileSize(-1024)).toBe('NaN undefined');
+  });
+});

--- a/src/frontend/apps/web/src/features/file-upload/lib/validateFiles.test.ts
+++ b/src/frontend/apps/web/src/features/file-upload/lib/validateFiles.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  validateFileSize,
+  validateFileType,
+  validateTotalFileSize,
+  MAX_IMAGE_SIZE,
+  MAX_VIDEO_SIZE,
+  MAX_TOTAL_FILE_SIZE,
+} from './validateFiles.utils';
+import { formatFileSize } from './formatFileSize.util';
+
+// Mock the alert function
+global.alert = vi.fn();
+
+// Mock formatFileSize function
+vi.mock('./formatFileSize.util', () => ({
+  formatFileSize: vi.fn((size) => `${(size / (1024 * 1024)).toFixed(2)}MB`),
+}));
+
+describe('File Validation Functions', () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.clearAllMocks();
+  });
+
+  describe('validateFileSize', () => {
+    it('should return true for image files under 20MB', () => {
+      const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
+      Object.defineProperty(file, 'size', { value: 10 * 1024 * 1024 });
+
+      expect(validateFileSize(file)).toBe(true);
+      expect(global.alert).not.toHaveBeenCalled();
+    });
+
+    it('should return false for image files over 20MB', () => {
+      const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
+      Object.defineProperty(file, 'size', { value: 25 * 1024 * 1024 });
+
+      expect(validateFileSize(file)).toBe(false);
+      expect(global.alert).toHaveBeenCalledWith(
+        'Image size should not exceed 20MB',
+      );
+    });
+
+    it('should return true for video files under 200MB', () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      Object.defineProperty(file, 'size', { value: 100 * 1024 * 1024 });
+
+      expect(validateFileSize(file)).toBe(true);
+      expect(global.alert).not.toHaveBeenCalled();
+    });
+
+    it('should return false for video files over 200MB', () => {
+      const file = new File([''], 'test.mp4', { type: 'video/mp4' });
+      Object.defineProperty(file, 'size', { value: 250 * 1024 * 1024 });
+
+      expect(validateFileSize(file)).toBe(false);
+      expect(global.alert).toHaveBeenCalledWith(
+        'Video size should not exceed 200MB',
+      );
+    });
+
+    it('should return false for non-image and non-video files', () => {
+      const file = new File([''], 'test.pdf', { type: 'application/pdf' });
+
+      expect(validateFileSize(file)).toBe(false);
+      expect(global.alert).toHaveBeenCalledWith(
+        'Only image and video files are supported',
+      );
+    });
+
+    it('should validate against the correct size constants', () => {
+      expect(MAX_IMAGE_SIZE).toBe(20 * 1024 * 1024);
+      expect(MAX_VIDEO_SIZE).toBe(200 * 1024 * 1024);
+    });
+  });
+
+  describe('validateFileType', () => {
+    it('should return true for supported image types', () => {
+      const supportedTypes = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'image/webp',
+      ];
+
+      supportedTypes.forEach((type) => {
+        const file = new File([''], `test.${type.split('/')[1]}`, { type });
+        expect(validateFileType(file)).toBe(true);
+        expect(global.alert).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should return false for forbidden image types', () => {
+      const forbiddenTypes = ['image/svg+xml', 'image/heic', 'image/heif'];
+
+      forbiddenTypes.forEach((type) => {
+        const file = new File([''], `test.${type.split('/')[1]}`, { type });
+        vi.clearAllMocks(); // Clear mocks between iterations
+
+        expect(validateFileType(file)).toBe(false);
+        expect(global.alert).toHaveBeenCalledWith(
+          'SVG, HEIC, HEIF files are not supported',
+        );
+      });
+    });
+
+    it('should return true for video files', () => {
+      const videoTypes = ['video/mp4', 'video/webm', 'video/ogg'];
+
+      videoTypes.forEach((type) => {
+        const file = new File([''], `test.${type.split('/')[1]}`, { type });
+        vi.clearAllMocks(); // Clear mocks between iterations
+
+        expect(validateFileType(file)).toBe(true);
+        expect(global.alert).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should return false for non-image and non-video files', () => {
+      const file = new File([''], 'test.pdf', { type: 'application/pdf' });
+
+      expect(validateFileType(file)).toBe(false);
+      expect(global.alert).toHaveBeenCalledWith(
+        'Only image and video files are supported',
+      );
+    });
+  });
+
+  describe('validateTotalFileSize', () => {
+    it('should return true when total file size is under 1000MB', () => {
+      const files = [
+        createFileMock('image/jpeg', 300 * 1024 * 1024),
+        createFileMock('video/mp4', 400 * 1024 * 1024),
+      ];
+
+      expect(validateTotalFileSize(files)).toBe(true);
+      expect(global.alert).not.toHaveBeenCalled();
+    });
+
+    it('should return false when total file size exceeds 1000MB', () => {
+      const files = [
+        createFileMock('image/jpeg', 300 * 1024 * 1024),
+        createFileMock('video/mp4', 800 * 1024 * 1024),
+      ];
+
+      expect(validateTotalFileSize(files)).toBe(false);
+      expect(formatFileSize).toHaveBeenCalledWith(1100 * 1024 * 1024);
+      expect(global.alert).toHaveBeenCalledWith(
+        '총 파일 크기가 1000MB를 초과할 수 없습니다. (현재: 1100.00MB)',
+      );
+    });
+
+    it('should validate against the correct MAX_TOTAL_FILE_SIZE constant', () => {
+      expect(MAX_TOTAL_FILE_SIZE).toBe(1000 * 1024 * 1024);
+    });
+
+    it('should handle empty file array', () => {
+      expect(validateTotalFileSize([])).toBe(true);
+      expect(global.alert).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// Helper function to create file mocks with custom size
+function createFileMock(type: string, size: number): File {
+  const file = new File([''], `test.${type.split('/')[1]}`, { type });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}

--- a/src/frontend/apps/web/src/features/file-upload/model/useFileManagements.test.tsx
+++ b/src/frontend/apps/web/src/features/file-upload/model/useFileManagements.test.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
+import { useFileManagements } from './useFileManagements';
+
+vi.mock('../lib', () => ({
+  validateFileType: vi.fn(),
+  validateTotalFileSize: vi.fn(),
+  processFile: vi.fn(),
+  createChunks: vi.fn(),
+  generateTempFileIdentifier: vi.fn(),
+}));
+vi.mock('../api', () => ({
+  uploadSmallFiles: vi.fn(),
+  uploadChunksQueue: vi.fn(),
+  uploadThumbnail: vi.fn(),
+}));
+
+// 모킹한 함수들을 import (각각 vi.Mock 으로 타입 단언)
+import {
+  validateFileType,
+  validateTotalFileSize,
+  processFile,
+  createChunks,
+  generateTempFileIdentifier,
+} from '../lib';
+import { uploadSmallFiles, uploadChunksQueue, uploadThumbnail } from '../api';
+
+// --- URL API 모킹 ---
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+beforeEach(() => {
+  URL.createObjectURL = vi.fn((file: File) => `blob:${file.name}`);
+  URL.revokeObjectURL = vi.fn();
+});
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
+// --- document.createElement 모킹 (미리보기 생성에 사용) ---
+const originalCreateElement = document.createElement;
+beforeEach(() => {
+  document.createElement = (tagName: string) => {
+    if (tagName === 'video') {
+      const video: Partial<HTMLVideoElement> & {
+        trigger?: (event: string) => void;
+      } = {
+        autoplay: false,
+        muted: true,
+        preload: 'metadata',
+        currentTime: 0,
+        duration: 10,
+        videoWidth: 1920,
+        videoHeight: 1080,
+        onloadedmetadata: null,
+        onseeked: null,
+        onerror: null,
+        src: '',
+      };
+      video.trigger = () => {
+        if (video.onloadedmetadata) {
+          (video as HTMLVideoElement).onloadedmetadata({} as Event);
+        }
+        if (video.onseeked) {
+          (video as HTMLVideoElement).onseeked({} as Event);
+        }
+      };
+      return video as HTMLVideoElement;
+    }
+    return originalCreateElement.call(document, tagName);
+  };
+});
+afterEach(() => {
+  document.createElement = originalCreateElement;
+});
+
+// --- 내부 캐시 초기화 ---
+import { blobUrlCache, processedFiles } from '../lib/filesUpload.utils';
+const clearCaches = () => {
+  blobUrlCache.clear();
+  processedFiles.clear();
+};
+
+// 테스트에서 사용될 wrapper (필요시 Context Provider 등을 추가)
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <>{children}</>;
+};
+
+describe('useFileManagements', () => {
+  const workspaceId = 1;
+  const channelId = 101;
+  const userId = 123;
+
+  beforeEach(() => {
+    // 기본 모킹 설정
+    (validateFileType as unknown as Mock).mockReturnValue(true);
+    (validateTotalFileSize as unknown as Mock).mockReturnValue(true);
+    (processFile as unknown as Mock).mockImplementation(async (file: File) => {
+      // 이미지 파일은 그대로 반환, 비디오 파일은 썸네일 생성 성공
+      if (file.type.startsWith('video/')) {
+        return {
+          file,
+          thumbnailFile: new File(['thumb'], 'thumbnail.webp', {
+            type: 'image/webp',
+          }),
+        };
+      }
+      return { file, thumbnailFile: undefined };
+    });
+    (createChunks as unknown as Mock).mockResolvedValue([]);
+    (generateTempFileIdentifier as unknown as Mock).mockReturnValue(
+      'temp-identifier',
+    );
+    (uploadSmallFiles as unknown as Mock).mockResolvedValue({
+      code: '200',
+      fileId: 1001,
+      status: 'success',
+    });
+    (uploadChunksQueue as unknown as Mock).mockResolvedValue([]);
+    (uploadThumbnail as unknown as Mock).mockResolvedValue({
+      code: '200',
+      status: 'success',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('파일 선택 시, 불허 파일 타입이 있으면 처리를 중단한다', async () => {
+    (validateFileType as unknown as Mock).mockReturnValueOnce(false);
+    const { result } = renderHook(
+      () => useFileManagements(workspaceId, channelId, userId),
+      { wrapper },
+    );
+    const file = new File(['dummy'], 'invalid.txt', { type: 'text/plain' });
+    const event = {
+      target: { files: [file], value: 'initial' },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+    await act(async () => {
+      await result.current.handleFileChange(event);
+    });
+    expect(result.current.filePreviews).toEqual([]);
+    expect(result.current.isFinalLoading).toBe(false);
+  });
+
+  it('파일 전체 사이즈 검증 실패 시 처리를 중단한다', async () => {
+    (validateTotalFileSize as unknown as Mock).mockReturnValueOnce(false);
+    const { result } = renderHook(
+      () => useFileManagements(workspaceId, channelId, userId),
+      { wrapper },
+    );
+    const file = new File(['dummy'], 'image.png', { type: 'image/png' });
+    const event = {
+      target: { files: [file], value: 'initial' },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+    await act(async () => {
+      await result.current.handleFileChange(event);
+    });
+    expect(result.current.filePreviews).toEqual([]);
+    expect(result.current.isFinalLoading).toBe(false);
+  });
+
+  it('파일 선택 시 미리보기 데이터를 생성하고, thumbnail URL이 업데이트된다 (비디오 파일의 경우)', async () => {
+    // 이미지와 비디오 파일 두 개를 선택하는 경우로 테스트
+    const { result } = renderHook(
+      () => useFileManagements(workspaceId, channelId, userId),
+      { wrapper },
+    );
+    const imageFile = new File(['image content'], 'photo.png', {
+      type: 'image/png',
+      lastModified: Date.now(),
+    });
+    const videoFile = new File(['video content'], 'video.mp4', {
+      type: 'video/mp4',
+      lastModified: Date.now(),
+    });
+    const event = {
+      target: { files: [imageFile, videoFile], value: 'initial' },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+    await act(async () => {
+      await result.current.handleFileChange(event);
+    });
+
+    await waitFor(() => {
+      expect(result.current.filePreviews.length).toBe(2);
+    });
+    const previews = result.current.filePreviews;
+    // 이미지 파일의 미리보기 URL
+    expect(
+      previews.find((fp) => fp.file.name === imageFile.name)?.previewUrl,
+    ).toBe(`blob:${imageFile.name}`);
+    // 비디오 파일의 미리보기 URL
+    expect(
+      previews.find((fp) => fp.file.name === videoFile.name)?.previewUrl,
+    ).toBe(`blob:${videoFile.name}`);
+    // processFile 모킹에 따라, 비디오 파일에 대한 thumbnail URL이 업데이트되어야 함
+    await waitFor(() => {
+      expect(
+        previews.find((fp) => fp.file.name === videoFile.name)?.thumbnailUrl,
+      ).toBeDefined();
+    });
+  });
+
+  it('업로드 로직: 10MB 이하 파일의 경우 uploadSmallFiles 및 (비디오일 경우) uploadThumbnail을 호출하고, uploadedFileIds를 업데이트한다', async () => {
+    const smallFile = new File([new Uint8Array(5 * 1024 * 1024)], 'small.png', {
+      type: 'image/png',
+    });
+    // 이미지 파일은 processFile가 thumbnail 없이 반환하도록 모킹
+    (processFile as unknown as Mock).mockResolvedValue({
+      file: smallFile,
+      thumbnailFile: undefined,
+    });
+    const { result } = renderHook(
+      () => useFileManagements(workspaceId, channelId, userId),
+      { wrapper },
+    );
+    const event = {
+      target: { files: [smallFile], value: 'initial' },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+    await act(async () => {
+      await result.current.handleFileChange(event);
+    });
+    expect(uploadSmallFiles).toHaveBeenCalled();
+    expect(result.current.uploadedFileIds).toContain(1001);
+  });
+
+  it('handleRemoveFile: 파일 미리보기를 제거한다', async () => {
+    const { result } = renderHook(
+      () => useFileManagements(workspaceId, channelId, userId),
+      { wrapper },
+    );
+    act(() => {
+      result.current.setFilePreviews([
+        {
+          id: '1',
+          file: new File(['dummy'], 'a.png'),
+          previewUrl: 'url-a',
+          isLoading: false,
+        },
+        {
+          id: '2',
+          file: new File(['dummy'], 'b.png'),
+          previewUrl: 'url-b',
+          isLoading: false,
+        },
+      ]);
+    });
+    act(() => {
+      result.current.handleRemoveFile(0);
+    });
+    expect(result.current.filePreviews.length).toBe(1);
+    expect(result.current.filePreviews[0].id).toBe('2');
+  });
+
+  it('에러 발생 시, catch 블록이 실행되어 error 상태가 설정되고 isFinalLoading이 false가 된다', async () => {
+    (processFile as unknown as Mock).mockRejectedValue(new Error('Test error'));
+    const { result } = renderHook(
+      () => useFileManagements(workspaceId, channelId, userId),
+      { wrapper },
+    );
+    const file = new File(['dummy'], 'error.mp4', { type: 'video/mp4' });
+    const event = {
+      target: { files: [file], value: 'initial' },
+    } as unknown as React.ChangeEvent<HTMLInputElement>;
+    await act(async () => {
+      await result.current.handleFileChange(event);
+    });
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.message).toBe('Test error');
+    expect(result.current.isFinalLoading).toBe(false);
+  });
+});

--- a/src/frontend/apps/web/tsconfig.json
+++ b/src/frontend/apps/web/tsconfig.json
@@ -12,7 +12,7 @@
         "name": "next"
       }
     ],
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals", "@testing-library/jest-dom", "node"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
# Pull request

<!---
IMPORTANT: Please do not create a Pull Request without first creating an issue and
reading our contributing guidelines (docs/CONTRIBUTING.md)

You can skip this if you're fixing a typo.
--->

## Related issue

<!---
Copybara Action only accepts pull requests related to open issues
If suggesting a new feature or change, please discuss it in an issue first
If fixing a bug, there should be an issue describing it with steps to reproduce
Please link to the issue here
-->
- Resolve #336 @KimKyuHoi 

## Motivation and context

<!---
Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.
--->

- 나머지 로직의 테스트 코드를 작성합니다.

## Solution

<!---
Describe the modifications you've done.
What will change as a result of your pull request?
--->

- file-upload 테스트 코드를 작성하였습니다.

## How has this been tested

<!---
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.
If this change has an impact on UX, include screenshots or a video.
--->

- 모든 로직부분만 테스트코드를 전부 작성하였습니다. 
- 최종 테스트 커버리지 평균 95% 달성하였습니다.

```zsh
-------------------------------|---------|----------|---------|---------|-------------------
File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------------|---------|----------|---------|---------|-------------------
All files                      |   95.31 |     97.4 |   96.77 |   95.31 |                   
 alarm/model                   |     100 |      100 |     100 |     100 |                   
  ToastAlarm.ts                |     100 |      100 |     100 |     100 |                   
 auth/model                    |     100 |      100 |     100 |     100 |                   
  useLoginRedirect.ts          |     100 |      100 |     100 |     100 |                   
  useLogout.ts                 |     100 |      100 |     100 |     100 |                   
 chat/lib                      |     100 |      100 |     100 |     100 |                   
  formatChatTime.util.ts       |     100 |      100 |     100 |     100 |                   
  formatDate.util.ts           |     100 |      100 |     100 |     100 |                   
  formatToKoreanDate.util.ts   |     100 |      100 |     100 |     100 |                   
  processChatHistory.util.ts   |     100 |      100 |     100 |     100 |                   
  processMessage.util.ts       |     100 |      100 |     100 |     100 |                   
 chat/model                    |     100 |      100 |     100 |     100 |                   
  useChatAutoScroll.ts         |     100 |      100 |     100 |     100 |                   
  useChatMessages.ts           |     100 |      100 |     100 |     100 |                   
  useChatSubscribe.ts          |     100 |      100 |     100 |     100 |                   
  useForwardInfiniteHistory.ts |     100 |      100 |     100 |     100 |                   
  useInvalidateChatHistory.ts  |     100 |      100 |     100 |     100 |                   
  useReverseInfiniteHistory.ts |     100 |      100 |     100 |     100 |                   
  useSendMessage.ts            |     100 |      100 |     100 |     100 |                   
 file-upload/lib               |   95.39 |    95.52 |   93.33 |   95.39 |                   
  chunkFiles.utils.ts          |     100 |      100 |     100 |     100 |                   
  filesUpload.utils.ts         |   89.13 |       85 |   83.33 |   89.13 | 78-79,84-89,91-92 
  formatFileSize.util.ts       |     100 |      100 |     100 |     100 |                   
  validateFiles.utils.ts       |     100 |      100 |     100 |     100 |                   
 file-upload/model             |   78.72 |    93.33 |     100 |   78.72 |                   
  useFileManagements.ts        |   78.72 |    93.33 |     100 |   78.72 | 104-135           
 stock/lib                     |     100 |      100 |     100 |     100 |                   
  stockChart.util.ts           |     100 |      100 |     100 |     100 |                   
  stockRealTime.util.ts        |     100 |      100 |     100 |     100 |                   
 stock/model                   |     100 |      100 |     100 |     100 |                   
  useStockChart.ts             |     100 |      100 |     100 |     100 |                   
  useStockWebSocket.ts         |     100 |      100 |     100 |     100 |                   
 user/model                    |     100 |      100 |     100 |     100 |                   
  profileChangeReducer.ts      |     100 |      100 |     100 |     100 |                   
 workspace/model               |   94.42 |    94.23 |      90 |   94.42 |                   
  useUnreadMessages.ts         |     100 |      100 |     100 |     100 |                   
  useUnreadSubscription.ts     |     100 |      100 |     100 |     100 |                   
  useWorkspaceChannels.ts      |   86.45 |    86.36 |      75 |   86.45 | 52,115-126        
  useWorkspaceMessages.ts      |     100 |      100 |     100 |     100 |                   
  useWorkspaceSubscription.ts  |     100 |      100 |     100 |     100 |                   
-------------------------------|---------|----------|---------|---------|-------------------
 PASS  Waiting for file changes...
       press h to show help, press q to quit
```
<!-- project-pull-request -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
